### PR TITLE
Feature/docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,24 @@ clean_fixtures:
 # extra dep for PostgreSQL targets in pgxs.mk
 clean: clean_fixtures
 
+# Docker stuff
+DOCKER_COMPOSE_COMMAND_TESTS=docker-compose --file hosting/tests/docker-compose.yml --project-directory .
+DOCKER_COMPOSE_COMMAND_FINAL=docker-compose --file hosting/final/docker-compose.yml --project-directory .
+docker-build-test:
+	$(DOCKER_COMPOSE_COMMAND_TESTS) build
+	$(DOCKER_COMPOSE_COMMAND_TESTS) down --remove-orphans
+	$(DOCKER_COMPOSE_COMMAND_TESTS) up -d
+	sleep 3
+	docker logs postgrest-openapi_postgrest-openapi-build_1
+docker-build: docker-build-test
+	$(DOCKER_COMPOSE_COMMAND_FINAL) build
+	$(DOCKER_COMPOSE_COMMAND_FINAL) down --remove-orphans
+	$(DOCKER_COMPOSE_COMMAND_FINAL) up -d
+
+# Postgres stuff
 TESTS = $(wildcard test/sql/*.sql)
 REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
-REGRESS_OPTS = --use-existing --inputdir=test
+REGRESS_OPTS = --use-existing --inputdir=test --outputdir=output
 
 EXTRA_CLEAN = sql/$(EXTENSION).sql sql/$(EXTENSION)--$(EXTVERSION).sql $(EXTENSION).control
 

--- a/Makefile
+++ b/Makefile
@@ -27,18 +27,26 @@ clean_fixtures:
 clean: clean_fixtures
 
 # Docker stuff
-DOCKER_COMPOSE_COMMAND_TESTS=docker-compose --file hosting/tests/docker-compose.yml --project-directory .
-DOCKER_COMPOSE_COMMAND_FINAL=docker-compose --file hosting/final/docker-compose.yml --project-directory .
+DOCKER_COMPOSE_COMMAND_BASE=docker-compose --project-directory . --env-file hosting/environment.env
+DOCKER_COMPOSE_COMMAND_TESTS=$(DOCKER_COMPOSE_COMMAND_BASE) --file hosting/tests/docker-compose.yml
 docker-build-test:
-	$(DOCKER_COMPOSE_COMMAND_TESTS) build
+	$(DOCKER_COMPOSE_COMMAND_TESTS) build --force
 	$(DOCKER_COMPOSE_COMMAND_TESTS) down --remove-orphans
 	$(DOCKER_COMPOSE_COMMAND_TESTS) up -d
 	sleep 3
 	docker logs postgrest-openapi_postgrest-openapi-build_1
+
+DOCKER_COMPOSE_COMMAND_FINAL=$(DOCKER_COMPOSE_COMMAND_BASE) --file hosting/final/docker-compose.yml
 docker-build: docker-build-test
 	$(DOCKER_COMPOSE_COMMAND_FINAL) build
 	$(DOCKER_COMPOSE_COMMAND_FINAL) down --remove-orphans
 	$(DOCKER_COMPOSE_COMMAND_FINAL) up -d
+
+DOCKER_COMPOSE_COMMAND_BAR=$(DOCKER_COMPOSE_COMMAND_BASE) --file hosting/build-and-run/docker-compose.yml
+docker-build-and-run: docker-build
+	$(DOCKER_COMPOSE_COMMAND_BAR) build
+	$(DOCKER_COMPOSE_COMMAND_BAR) down --remove-orphans
+	$(DOCKER_COMPOSE_COMMAND_BAR) up -d
 
 # Postgres stuff
 TESTS = $(wildcard test/sql/*.sql)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ For those who insist on Docker:
 ```bash
 # To build a docker image and run the tests in it
 make docker-build-test
+
+# To build a docker image for actual use
+make docker-build
 ```
 
 ## References

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ nix-shell --run "with-pg-15 psql contrib_regression"
 nix-shell --run "with-pg-13 make installcheck"
 ```
 
+For those who insist on Docker:
+```bash
+# To build a docker image and run the tests in it
+make docker-build-test
+```
+
 ## References
 
 - [OpenAPI 3 Specification Documentation](https://spec.openapis.org/oas/v3.1.0): The official documentation of the spec.

--- a/hosting/Dockerfile
+++ b/hosting/Dockerfile
@@ -1,0 +1,32 @@
+##### Base #####
+FROM postgres:16-alpine AS postgres-openapi-base
+
+
+ENV extension_dir=/usr/local/share/postgresql/extension
+ENV extensionName=postgrest_openapi
+ENV build_dir=/buildroot
+ENV out_dir=$build_dir/output
+
+##### Build/Text #####
+FROM postgres-openapi-base AS postgres-openapi-build
+
+RUN apk --no-cache add make
+
+RUN mkdir -p $build_dir/sql $build_dir/test $out_dir/ && chown postgres:postgres $out_dir/
+
+COPY Makefile postgrest_openapi.control.in $build_dir/
+COPY sql $build_dir/sql/
+COPY test $build_dir/test/
+
+# Do a build, install, and setup
+RUN cd $build_dir && make && make install
+
+COPY hosting/tests/scripts/run-tests.sh /docker-entrypoint-initdb.d/
+RUN chmod a+x /docker-entrypoint-initdb.d/run-tests.sh
+
+##### Final #####
+FROM postgres-openapi-base AS postgres-openapi
+
+RUN mkdir $extension_dir/bin
+COPY sql/*.sql $extension_dir/share/postgresql/extension/
+COPY --from=postgres-openapi-build $build_dir/${extensionName}.control $extension_dir/share/postgresql/extension/

--- a/hosting/Dockerfile
+++ b/hosting/Dockerfile
@@ -2,8 +2,10 @@
 FROM postgres:16-alpine AS postgres-openapi-base
 
 
-ENV extension_dir=/usr/local/share/postgresql/extension
 ENV extensionName=postgrest_openapi
+ENV extensionVersion=0.0.1
+
+ENV extension_dir=/usr/local/share/postgresql/extension
 ENV build_dir=/buildroot
 ENV out_dir=$build_dir/output
 
@@ -28,5 +30,6 @@ RUN chmod a+x /docker-entrypoint-initdb.d/run-tests.sh
 FROM postgres-openapi-base AS postgres-openapi
 
 RUN mkdir $extension_dir/bin
-COPY sql/*.sql $extension_dir/share/postgresql/extension/
-COPY --from=postgres-openapi-build $build_dir/${extensionName}.control $extension_dir/share/postgresql/extension/
+COPY --from=postgres-openapi-build $build_dir/sql/${extensionName}--${extensionVersion}.sql $extension_dir/
+COPY --from=postgres-openapi-build $build_dir/${extensionName}.control $extension_dir/
+COPY hosting/build-and-run/scripts/initdb.sql /docker-entrypoint-initdb.d/

--- a/hosting/build-and-run/docker-compose.yml
+++ b/hosting/build-and-run/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3'
+
+services:
+  postgres:
+    build:
+      context: .
+      dockerfile: hosting/Dockerfile
+      target: postgres-openapi
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+
+  postgrest:
+    container_name: ${PROJECT_NAME}-postgrest
+    image: postgrest/postgrest:latest
+    ports:
+      - "3005:3000"
+    # Available environment variables documented here:
+    # https://postgrest.org/en/latest/configuration.html#environment-variables
+    environment:
+      # The standard connection URI format, documented at
+      # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+      - PGRST_DB_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${API_DB}
+      # The name of which database schema to expose to REST clients
+      - PGRST_DB_SCHEMA=${DB_SCHEMA}
+      # The database role to use when no client authentication is provided
+#      - PGRST_DB_ANON_ROLE=${DB_ANON_ROLE}
+      - PGRST_DB_ANON_ROLE=${POSTGRES_USER}
+      # Overrides the base URL used within the OpenAPI self-documentation hosted at the API root path
+      - PGRST_OPENAPI_SERVER_PROXY_URI=http://localhost:3000
+      # Overrides the old inbuilt OpenAPI with the new extension one
+      - PGRST_DB_ROOT_SPEC=callable_root

--- a/hosting/build-and-run/scripts/initdb.sql
+++ b/hosting/build-and-run/scripts/initdb.sql
@@ -1,0 +1,4 @@
+CREATE SCHEMA api;
+SET SEARCH_PATH = api;
+
+CREATE EXTENSION postgrest_openapi;

--- a/hosting/environment.env
+++ b/hosting/environment.env
@@ -1,0 +1,27 @@
+#############################
+# General USS Configuration #
+#############################
+PROJECT_NAME=postgrest-openapi
+
+PROJECT_DATABASE=${PROJECT_NAME}
+
+##############################
+# USS Database Configuration #
+##############################
+
+# PostgreSQL master admin username and password
+POSTGRES_HOSTNAME=${PROJECT_NAME}-postgres
+POSTGRES_DB=${PROJECT_DATABASE}
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=password
+
+#########################
+# USS API Configuration #
+#########################
+
+# PostgREST
+DB_SCHEMA=api
+API_DB=${PROJECT_DATABASE}
+
+DB_ANON_USER=anon
+DB_ANON_ROLE=db_${API_DB}_anonymous

--- a/hosting/final/docker-compose.yml
+++ b/hosting/final/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  postgrest-openapi-build:
+    build:
+      context: .
+      dockerfile: hosting/Dockerfile
+      target: postgres-openapi
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=test_db

--- a/hosting/tests/docker-compose.yml
+++ b/hosting/tests/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  postgrest-openapi-build:
+#    image: postgres-openapi-test
+    build:
+      context: .
+      dockerfile: hosting/Dockerfile
+      target: postgres-openapi-build
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=test_db

--- a/hosting/tests/scripts/run-tests.sh
+++ b/hosting/tests/scripts/run-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd /buildroot
+
+set -o xtrace
+
+make fixtures
+make installcheck

--- a/postgrest_openapi.control.in
+++ b/postgrest_openapi.control.in
@@ -1,2 +1,6 @@
+# Initially relocatable, but not after creation.  If we want to change this, go to https://wiki.postgresql.org/wiki/Extensions and read the set_schema section (right near the bottom)
 relocatable = false
 default_version = '@EXTVERSION@'
+comment = 'OpenAPI extension for PostgREST (requires PostgREST)'
+# FIX: Not required for tests, but should be required in production
+#requires = 'postgrest'

--- a/postgrest_openapi.control.in
+++ b/postgrest_openapi.control.in
@@ -2,5 +2,3 @@
 relocatable = false
 default_version = '@EXTVERSION@'
 comment = 'OpenAPI extension for PostgREST (requires PostgREST)'
-# FIX: Not required for tests, but should be required in production
-#requires = 'postgrest'


### PR DESCRIPTION
Hi!  

I found that:
- There was no setup for Docker, which is something that a lot of people would be looking for
- I wasn't interested in installing Nix when their recommended installation method said "Turn off selinux"

So, I made a docker setup that will allow people to run:
- `make docker-build-test` -- this runs the tests in a docker container
- `make docker-build` -- this builds a docker image for use containing PostgREST-OpenAPI

Hopefully not needing Nix (though it's still there) will enable more people to get into the development.

Thanks!  

**Edit:** Also added a `make docker build-and-run` which should produce a running version with postgrest attached; useful for development