### PR TITLE
Fix non unique Prefer header in Component Object

### DIFF
--- a/sql/components.sql
+++ b/sql/components.sql
@@ -64,7 +64,8 @@ select jsonb_build_object(
       oas_schema_object(
         description := 'Send JSON as a single parameter',
         type := 'string',
-        "enum" := '["single-object"]'
+        "enum" := '["single-object"]',
+        deprecated := true
       )
     )
   ),

--- a/sql/openapi.sql
+++ b/sql/openapi.sql
@@ -243,3 +243,19 @@ $$
     'openIdConnectUrl', openIdConnectUrl
   );
 $$;
+
+create or replace function oas_example_object(
+  summary text default null,
+  description text default null,
+  value jsonb default null,
+  externalValue text default null
+)
+returns jsonb language sql as
+$$
+  select jsonb_build_object(
+    'summary', summary,
+    'description', description,
+    'value', value,
+    'externalValue', externalValue
+  );
+$$;

--- a/test/expected/parameters.out
+++ b/test/expected/parameters.out
@@ -17,20 +17,267 @@ where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'o
 (10 rows)
 
 -- shows common headers
-select *
+select key, jsonb_pretty(value)
 from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'parameters')
-where key in ('preferParams', 'preferReturn', 'preferCount', 'preferResolution', 'preferTransaction', 'preferMissing', 'preferHandling', 'preferTimezone', 'preferMaxAffected', 'range');
-        key        |                                                                                                   value                                                                                                    
--------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- range             | {"in": "header", "name": "Range", "schema": {"type": "string"}, "example": "5-10", "description": "For limits and pagination"}
- preferCount       | {"in": "header", "name": "Prefer", "schema": {"enum": ["count=exact", "count=planned", "count=estimated"], "type": "string"}, "description": "Get the total size of the table"}
- preferParams      | {"in": "header", "name": "Prefer", "schema": {"enum": ["params=single-object"], "type": "string"}, "description": "Send JSON as a single parameter"}
- preferReturn      | {"in": "header", "name": "Prefer", "schema": {"enum": ["return=minimal", "return=headers-only", "return=representation"], "type": "string"}, "description": "Return information of the affected resource"}
- preferMissing     | {"in": "header", "name": "Prefer", "schema": {"enum": ["missing=default", "missing=null"], "type": "string"}, "description": "Handle null values in bulk inserts"}
- preferHandling    | {"in": "header", "name": "Prefer", "schema": {"enum": ["handling=strict", "handling=lenient"], "type": "string"}, "description": "Handle invalid preferences"}
- preferTimezone    | {"in": "header", "name": "Prefer", "schema": {"type": "string"}, "example": "timezone=UTC", "description": "Specify the time zone"}
- preferResolution  | {"in": "header", "name": "Prefer", "schema": {"enum": ["resolution=merge-duplicates", "resolution=ignore-duplicates"], "type": "string"}, "description": "Handle duplicates in an upsert"}
- preferMaxAffected | {"in": "header", "name": "Prefer", "schema": {"type": "string"}, "example": "max-affected=5", "description": "Limit the number of affected resources"}
- preferTransaction | {"in": "header", "name": "Prefer", "schema": {"enum": ["tx=commit", "tx=rollback"], "type": "string"}, "description": "Specify how to end a transaction"}
-(10 rows)
+where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDelete', 'preferPostRpc', 'range');
+      key      |                                 jsonb_pretty                                 
+---------------+------------------------------------------------------------------------------
+ range         | {                                                                           +
+               |     "in": "header",                                                         +
+               |     "name": "Range",                                                        +
+               |     "schema": {                                                             +
+               |         "type": "string"                                                    +
+               |     },                                                                      +
+               |     "example": "5-10",                                                      +
+               |     "description": "For limits and pagination"                              +
+               | }
+ preferGet     | {                                                                           +
+               |     "in": "header",                                                         +
+               |     "name": "Prefer",                                                       +
+               |     "schema": {                                                             +
+               |         "allOf": [                                                          +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferHandling"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTimezone"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferCount"           +
+               |             }                                                               +
+               |         ]                                                                   +
+               |     },                                                                      +
+               |     "explode": true,                                                        +
+               |     "examples": {                                                           +
+               |         "all": {                                                            +
+               |             "value": {                                                      +
+               |                 "count": "",                                                +
+               |                 "handling": "lenient",                                      +
+               |                 "timezone": ""                                              +
+               |             },                                                              +
+               |             "summary": "All default preferences"                            +
+               |         },                                                                  +
+               |         "nothing": {                                                        +
+               |             "summary": "No preferences"                                     +
+               |         }                                                                   +
+               |     },                                                                      +
+               |     "description": "Specify a required or optional behavior for the request"+
+               | }
+ preferPut     | {                                                                           +
+               |     "in": "header",                                                         +
+               |     "name": "Prefer",                                                       +
+               |     "schema": {                                                             +
+               |         "allOf": [                                                          +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferHandling"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTimezone"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferReturn"          +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferCount"           +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTx"              +
+               |             }                                                               +
+               |         ]                                                                   +
+               |     },                                                                      +
+               |     "explode": true,                                                        +
+               |     "examples": {                                                           +
+               |         "all": {                                                            +
+               |             "value": {                                                      +
+               |                 "tx": "commit",                                             +
+               |                 "count": "",                                                +
+               |                 "return": "minimal",                                        +
+               |                 "handling": "lenient",                                      +
+               |                 "timezone": ""                                              +
+               |             },                                                              +
+               |             "summary": "All default preferences"                            +
+               |         },                                                                  +
+               |         "nothing": {                                                        +
+               |             "summary": "No preferences"                                     +
+               |         }                                                                   +
+               |     },                                                                      +
+               |     "description": "Specify a required or optional behavior for the request"+
+               | }
+ preferPost    | {                                                                           +
+               |     "in": "header",                                                         +
+               |     "name": "Prefer",                                                       +
+               |     "schema": {                                                             +
+               |         "allOf": [                                                          +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferHandling"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTimezone"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferReturn"          +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferCount"           +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferResolution"      +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferMissing"         +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTx"              +
+               |             }                                                               +
+               |         ]                                                                   +
+               |     },                                                                      +
+               |     "explode": true,                                                        +
+               |     "examples": {                                                           +
+               |         "all": {                                                            +
+               |             "value": {                                                      +
+               |                 "tx": "commit",                                             +
+               |                 "count": "",                                                +
+               |                 "return": "minimal",                                        +
+               |                 "missing": "null",                                          +
+               |                 "handling": "lenient",                                      +
+               |                 "timezone": "",                                             +
+               |                 "resolution": ""                                            +
+               |             },                                                              +
+               |             "summary": "All default preferences"                            +
+               |         },                                                                  +
+               |         "nothing": {                                                        +
+               |             "summary": "No preferences"                                     +
+               |         }                                                                   +
+               |     },                                                                      +
+               |     "description": "Specify a required or optional behavior for the request"+
+               | }
+ preferPatch   | {                                                                           +
+               |     "in": "header",                                                         +
+               |     "name": "Prefer",                                                       +
+               |     "schema": {                                                             +
+               |         "allOf": [                                                          +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferHandling"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTimezone"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferReturn"          +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferCount"           +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTx"              +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferMaxAffected"     +
+               |             }                                                               +
+               |         ]                                                                   +
+               |     },                                                                      +
+               |     "explode": true,                                                        +
+               |     "examples": {                                                           +
+               |         "all": {                                                            +
+               |             "value": {                                                      +
+               |                 "tx": "commit",                                             +
+               |                 "count": "",                                                +
+               |                 "return": "minimal",                                        +
+               |                 "handling": "lenient",                                      +
+               |                 "timezone": "",                                             +
+               |                 "max-affected": ""                                          +
+               |             },                                                              +
+               |             "summary": "All default preferences"                            +
+               |         },                                                                  +
+               |         "nothing": {                                                        +
+               |             "summary": "No preferences"                                     +
+               |         }                                                                   +
+               |     },                                                                      +
+               |     "description": "Specify a required or optional behavior for the request"+
+               | }
+ preferDelete  | {                                                                           +
+               |     "in": "header",                                                         +
+               |     "name": "Prefer",                                                       +
+               |     "schema": {                                                             +
+               |         "allOf": [                                                          +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferHandling"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTimezone"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferReturn"          +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferCount"           +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTx"              +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferMaxAffected"     +
+               |             }                                                               +
+               |         ]                                                                   +
+               |     },                                                                      +
+               |     "explode": true,                                                        +
+               |     "examples": {                                                           +
+               |         "all": {                                                            +
+               |             "value": {                                                      +
+               |                 "tx": "commit",                                             +
+               |                 "count": "",                                                +
+               |                 "return": "minimal",                                        +
+               |                 "handling": "lenient",                                      +
+               |                 "timezone": "",                                             +
+               |                 "max-affected": ""                                          +
+               |             },                                                              +
+               |             "summary": "All default preferences"                            +
+               |         },                                                                  +
+               |         "nothing": {                                                        +
+               |             "summary": "No preferences"                                     +
+               |         }                                                                   +
+               |     },                                                                      +
+               |     "description": "Specify a required or optional behavior for the request"+
+               | }
+ preferPostRpc | {                                                                           +
+               |     "in": "header",                                                         +
+               |     "name": "Prefer",                                                       +
+               |     "schema": {                                                             +
+               |         "allOf": [                                                          +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferHandling"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTimezone"        +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferCount"           +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferTx"              +
+               |             },                                                              +
+               |             {                                                               +
+               |                 "$ref": "#/components/schemas/header.preferParams"          +
+               |             }                                                               +
+               |         ]                                                                   +
+               |     },                                                                      +
+               |     "explode": true,                                                        +
+               |     "examples": {                                                           +
+               |         "all": {                                                            +
+               |             "value": {                                                      +
+               |                 "tx": "commit",                                             +
+               |                 "count": "",                                                +
+               |                 "params": "",                                               +
+               |                 "handling": "lenient",                                      +
+               |                 "timezone": ""                                              +
+               |             },                                                              +
+               |             "summary": "All default preferences"                            +
+               |         },                                                                  +
+               |         "nothing": {                                                        +
+               |             "summary": "No preferences"                                     +
+               |         }                                                                   +
+               |     },                                                                      +
+               |     "description": "Specify a required or optional behavior for the request"+
+               | }
+(7 rows)
 

--- a/test/expected/schemas.out
+++ b/test/expected/schemas.out
@@ -326,6 +326,7 @@ where key like 'header.prefer%';
                           |                 "single-object"                                         +
                           |             ],                                                          +
                           |             "type": "string",                                           +
+                          |             "deprecated": true,                                         +
                           |             "description": "Send JSON as a single parameter"            +
                           |         }                                                               +
                           |     }                                                                   +

--- a/test/expected/schemas.out
+++ b/test/expected/schemas.out
@@ -285,3 +285,124 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
  }
 (1 row)
 
+-- defines all the available prefer headers
+select key, jsonb_pretty(value)
+from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'schemas')
+where key like 'header.prefer%';
+           key            |                               jsonb_pretty                               
+--------------------------+--------------------------------------------------------------------------
+ header.preferTx          | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "tx": {                                                         +
+                          |             "enum": [                                                   +
+                          |                 "commit",                                               +
+                          |                 "rollback"                                              +
+                          |             ],                                                          +
+                          |             "type": "string",                                           +
+                          |             "description": "Specify how to end a transaction"           +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferCount       | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "count": {                                                      +
+                          |             "enum": [                                                   +
+                          |                 "exact",                                                +
+                          |                 "planned",                                              +
+                          |                 "estimated"                                             +
+                          |             ],                                                          +
+                          |             "type": "string",                                           +
+                          |             "description": "Get the total size of the table"            +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferParams      | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "params": {                                                     +
+                          |             "enum": [                                                   +
+                          |                 "single-object"                                         +
+                          |             ],                                                          +
+                          |             "type": "string",                                           +
+                          |             "description": "Send JSON as a single parameter"            +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferReturn      | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "return": {                                                     +
+                          |             "enum": [                                                   +
+                          |                 "minimal",                                              +
+                          |                 "headers-only",                                         +
+                          |                 "representation"                                        +
+                          |             ],                                                          +
+                          |             "type": "string",                                           +
+                          |             "default": "minimal",                                       +
+                          |             "description": "Return information of the affected resource"+
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferMissing     | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "missing": {                                                    +
+                          |             "enum": [                                                   +
+                          |                 "default",                                              +
+                          |                 "null"                                                  +
+                          |             ],                                                          +
+                          |             "type": "string",                                           +
+                          |             "default": "null",                                          +
+                          |             "description": "Handle null values in bulk inserts"         +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferHandling    | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "handling": {                                                   +
+                          |             "enum": [                                                   +
+                          |                 "strict",                                               +
+                          |                 "lenient"                                               +
+                          |             ],                                                          +
+                          |             "type": "string",                                           +
+                          |             "default": "lenient",                                       +
+                          |             "description": "How to handle invalid preferences"          +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferTimezone    | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "timezone": {                                                   +
+                          |             "type": "string",                                           +
+                          |             "description": "Specify the time zone"                      +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferResolution  | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "resolution": {                                                 +
+                          |             "enum": [                                                   +
+                          |                 "merge-duplicates",                                     +
+                          |                 "ignore-duplicates"                                     +
+                          |             ],                                                          +
+                          |             "type": "string",                                           +
+                          |             "description": "Handle duplicates in an upsert"             +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+ header.preferMaxAffected | {                                                                       +
+                          |     "type": "object",                                                   +
+                          |     "properties": {                                                     +
+                          |         "max-affected": {                                               +
+                          |             "type": "integer",                                          +
+                          |             "description": "Specify the amount of resources affected"   +
+                          |         }                                                               +
+                          |     }                                                                   +
+                          | }
+(9 rows)
+

--- a/test/sql/parameters.sql
+++ b/test/sql/parameters.sql
@@ -4,6 +4,6 @@ from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'parameter
 where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'or', 'and', 'not.or', 'not.and');
 
 -- shows common headers
-select *
+select key, jsonb_pretty(value)
 from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'parameters')
-where key in ('preferParams', 'preferReturn', 'preferCount', 'preferResolution', 'preferTransaction', 'preferMissing', 'preferHandling', 'preferTimezone', 'preferMaxAffected', 'range');
+where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDelete', 'preferPostRpc', 'range');

--- a/test/sql/schemas.sql
+++ b/test/sql/schemas.sql
@@ -45,3 +45,8 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 
 -- references a composite type column from an array composite type inside the items property
 select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'colors'->'items');
+
+-- defines all the available prefer headers
+select key, jsonb_pretty(value)
+from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'schemas')
+where key like 'header.prefer%';


### PR DESCRIPTION
Closes #26

Changes done to fix repeating the Prefer header:
- Define a Schema Object for each Preference
- Define a Parameter Object for each HTTP method that references only the relevant preferences