### PR TITLE
Add paths with get requests for tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SQL functions to build the OpenAPI output of a PostgREST instance.
     - [ ] Parameters
   - [ ] Paths object
     - [ ] Tables and Views
-      - [ ] GET
+      - [x] GET
       - [ ] POST
       - [ ] PUT
       - [ ] DELETE

--- a/sql/components.sql
+++ b/sql/components.sql
@@ -195,7 +195,7 @@ from (
     ) as param_schema
   from (
      select table_schema, table_name, unnest(all_cols) as column_name
-     from postgrest_get_all_tables('{public}')
+     from postgrest_get_all_tables(schemas)
   ) _
   where table_schema = any(schemas)
 ) x;

--- a/sql/main.sql
+++ b/sql/main.sql
@@ -44,7 +44,7 @@ select oas_openapi_object(
     )
   ),
   servers := oas_build_servers(),
-  paths := '{}',
+  paths := oas_build_paths(schemas),
   components := oas_build_components(schemas),
   security := '[{"JWT": []}]'
 )

--- a/sql/openapi.sql
+++ b/sql/openapi.sql
@@ -264,3 +264,101 @@ $$
     'externalValue', externalValue
   );
 $$;
+
+create or replace function oas_path_item_object(
+  ref text default null,
+  summary text default null,
+  description text default null,
+  get jsonb default null,
+  put jsonb default null,
+  post jsonb default null,
+  delete jsonb default null,
+  options jsonb default null,
+  head jsonb default null,
+  patch jsonb default null,
+  trace jsonb default null,
+  servers jsonb default null,
+  parameters jsonb default null
+)
+returns jsonb language sql as
+$$
+  select json_build_object(
+    '$ref', ref,
+    'summary', summary,
+    'description', description,
+    'get', get,
+    'put', put,
+    'post', post,
+    'delete', delete,
+    'options', options,
+    'head', head,
+    'patch', patch,
+    'trace', trace,
+    'servers', servers,
+    'parameters', parameters
+  )
+$$;
+
+create or replace function oas_operation_object(
+  tags text[] default null,
+  summary text default null,
+  description text default null,
+  externalDocs jsonb default null,
+  operationId text default null,
+  parameters jsonb default null,
+  requestBody jsonb default null,
+  responses jsonb default null,
+  callbacks jsonb default null,
+  deprecated boolean default null,
+  security jsonb default null,
+  servers jsonb default null
+)
+returns jsonb language sql as
+$$
+  select json_build_object(
+    'tags', tags,
+    'summary', summary,
+    'description', description,
+    'externalDocs', externalDocs,
+    'operationId', operationId,
+    'parameters', parameters,
+    'requestBody', requestBody,
+    'responses', responses,
+    'callbacks', callbacks,
+    'deprecated', deprecated,
+    'security', security,
+    'servers', servers
+  )
+$$;
+
+create or replace function oas_response_object(
+  description text,
+  headers jsonb default null,
+  content jsonb default null,
+  links jsonb default null
+)
+returns jsonb language sql as
+$$
+  select json_build_object(
+    'description', description,
+    'headers', headers,
+    'content', content,
+    'links', links
+  )
+$$;
+
+create or replace function oas_media_type_object(
+  "schema" jsonb default null,
+  example text default null,
+  examples jsonb default null,
+  encoding jsonb default null
+)
+returns jsonb language sql as
+$$
+  select json_build_object(
+    'schema', "schema",
+    'example', example,
+    'examples', examples,
+    'encoding', encoding
+  )
+$$;

--- a/sql/paths.sql
+++ b/sql/paths.sql
@@ -1,0 +1,87 @@
+-- Functions to build the Paths Object of the OAS document
+
+create or replace function oas_build_paths(schemas text[])
+returns jsonb language sql as
+$$
+  select oas_build_path_item_root() ||
+         oas_build_path_items_from_tables(schemas);
+$$;
+
+create or replace function oas_build_path_items_from_tables(schemas text[])
+returns jsonb language sql as
+$$
+select jsonb_object_agg(x.path, x.oas_path_item)
+from (
+  select '/' || table_name as path,
+    oas_path_item_object(
+      get :=oas_operation_object(
+        description := table_description,
+        tags := array[table_name],
+        parameters := jsonb_agg(
+          oas_build_reference_to_parameters(format('rowFilter.%1$s.%2$s', table_name, column_name))
+        ) ||
+        jsonb_build_array(
+          oas_build_reference_to_parameters('select'),
+          oas_build_reference_to_parameters('order'),
+          oas_build_reference_to_parameters('limit'),
+          oas_build_reference_to_parameters('offset'),
+          oas_build_reference_to_parameters('or'),
+          oas_build_reference_to_parameters('and'),
+          oas_build_reference_to_parameters('not.or'),
+          oas_build_reference_to_parameters('not.and'),
+          oas_build_reference_to_parameters('range'),
+          oas_build_reference_to_parameters('preferGet')
+        ),
+        responses := jsonb_build_object(
+          '200',
+          oas_build_reference_to_responses('get.' || table_name, 'OK'),
+          '206',
+          oas_build_reference_to_responses('get.' || table_name, 'Partial Content'),
+          'default',
+          oas_build_reference_to_responses('defaultError', 'Error')
+        )
+      )
+    ) as oas_path_item
+  from (
+   select table_schema, table_name, table_description, unnest(all_cols) as column_name
+   from postgrest_get_all_tables(schemas)
+  ) _
+  where table_schema = any(schemas)
+  group by table_schema, table_name, table_description
+) x;
+$$;
+
+create or replace function oas_build_path_item_root()
+returns jsonb language sql as
+$$
+select
+  jsonb_build_object(
+    '/',
+    oas_path_item_object(
+      get := oas_operation_object(
+        description := 'OpenAPI description (this document)',
+        tags := array['Introspection'],
+        responses := jsonb_build_object(
+          '200',
+          oas_response_object(
+            description := 'OK',
+            content := jsonb_build_object(
+              'application/json',
+              oas_media_type_object(
+                schema := oas_schema_object(
+                  type := 'object'
+                )
+              ),
+              'application/openapi+json',
+              oas_media_type_object(
+                schema := oas_schema_object(
+                  type := 'object'
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  );
+$$;

--- a/sql/postgrest.sql
+++ b/sql/postgrest.sql
@@ -1,7 +1,7 @@
 -- Functions to get information from PostgREST to generate the OpenAPI output
 
 -- TODO: simplify the query to have only relevant info for OpenAPI
--- TODO: to keep it reusable it may need to return data as is, that is, not using OAS objects.
+-- TODO: to keep it reusable it may need to return data as is without using OAS objects.
 --       To do so, "columns" has to be normalized (not a JSON aggregate)
 create or replace function postgrest_get_all_tables(schemas text[])
 returns table (

--- a/sql/utils.sql
+++ b/sql/utils.sql
@@ -20,3 +20,20 @@ $$
     '#/components/schemas/' || "schema"
   );
 $$;
+
+create or replace function oas_build_reference_to_parameters(parameter text)
+returns jsonb language sql immutable as
+$$
+  select oas_reference_object(
+    '#/components/parameters/' || parameter
+  );
+$$;
+
+create or replace function oas_build_reference_to_responses(response text, descrip text default null)
+returns jsonb language sql immutable as
+$$
+  select oas_reference_object(
+    ref := '#/components/responses/' || response,
+    description := descrip
+  );
+$$;

--- a/test/expected/parameters.out
+++ b/test/expected/parameters.out
@@ -281,3 +281,89 @@ where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDele
                | }
 (7 rows)
 
+-- shows table columns as parameters
+select key, jsonb_pretty(value)
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+where key like 'rowFilter.products.%';
+              key               |        jsonb_pretty        
+--------------------------------+----------------------------
+ rowFilter.products.id          | {                         +
+                                |     "in": "query",        +
+                                |     "name": "id",         +
+                                |     "schema": {           +
+                                |         "type": "string"  +
+                                |     }                     +
+                                | }
+ rowFilter.products.attr        | {                         +
+                                |     "in": "query",        +
+                                |     "name": "attr",       +
+                                |     "schema": {           +
+                                |         "type": "string"  +
+                                |     }                     +
+                                | }
+ rowFilter.products.code        | {                         +
+                                |     "in": "query",        +
+                                |     "name": "code",       +
+                                |     "schema": {           +
+                                |         "type": "string"  +
+                                |     }                     +
+                                | }
+ rowFilter.products.name        | {                         +
+                                |     "in": "query",        +
+                                |     "name": "name",       +
+                                |     "schema": {           +
+                                |         "type": "string"  +
+                                |     }                     +
+                                | }
+ rowFilter.products.size        | {                         +
+                                |     "in": "query",        +
+                                |     "name": "size",       +
+                                |     "schema": {           +
+                                |         "type": "string"  +
+                                |     }                     +
+                                | }
+ rowFilter.products.description | {                         +
+                                |     "in": "query",        +
+                                |     "name": "description",+
+                                |     "schema": {           +
+                                |         "type": "string"  +
+                                |     }                     +
+                                | }
+(6 rows)
+
+-- shows view columns as parameters
+select key, jsonb_pretty(value)
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+where key like 'rowFilter.big_products.%';
+             key             |       jsonb_pretty       
+-----------------------------+--------------------------
+ rowFilter.big_products.id   | {                       +
+                             |     "in": "query",      +
+                             |     "name": "id",       +
+                             |     "schema": {         +
+                             |         "type": "string"+
+                             |     }                   +
+                             | }
+ rowFilter.big_products.code | {                       +
+                             |     "in": "query",      +
+                             |     "name": "code",     +
+                             |     "schema": {         +
+                             |         "type": "string"+
+                             |     }                   +
+                             | }
+ rowFilter.big_products.name | {                       +
+                             |     "in": "query",      +
+                             |     "name": "name",     +
+                             |     "schema": {         +
+                             |         "type": "string"+
+                             |     }                   +
+                             | }
+ rowFilter.big_products.size | {                       +
+                             |     "in": "query",      +
+                             |     "name": "size",     +
+                             |     "schema": {         +
+                             |         "type": "string"+
+                             |     }                   +
+                             | }
+(4 rows)
+

--- a/test/expected/parameters.out
+++ b/test/expected/parameters.out
@@ -28,7 +28,7 @@ where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDele
                |     "schema": {                                                             +
                |         "type": "string"                                                    +
                |     },                                                                      +
-               |     "example": "5-10",                                                      +
+               |     "example": "0-4",                                                       +
                |     "description": "For limits and pagination"                              +
                | }
  preferGet     | {                                                                           +

--- a/test/expected/parameters.out
+++ b/test/expected/parameters.out
@@ -1,6 +1,6 @@
 -- shows common query parameters
 select *
-from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'parameters')
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'or', 'and', 'not.or', 'not.and');
      key     |                                                                                     value                                                                                     
 -------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'o
 
 -- shows common headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'parameters')
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDelete', 'preferPostRpc', 'range');
       key      |                                 jsonb_pretty                                 
 ---------------+------------------------------------------------------------------------------

--- a/test/expected/paths.out
+++ b/test/expected/paths.out
@@ -1,0 +1,177 @@
+-- shows root path for the OpenAPI output
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/');
+                         jsonb_pretty                         
+--------------------------------------------------------------
+ {                                                           +
+     "get": {                                                +
+         "tags": [                                           +
+             "Introspection"                                 +
+         ],                                                  +
+         "responses": {                                      +
+             "200": {                                        +
+                 "content": {                                +
+                     "application/json": {                   +
+                         "schema": {                         +
+                             "type": "object"                +
+                         }                                   +
+                     },                                      +
+                     "application/openapi+json": {           +
+                         "schema": {                         +
+                             "type": "object"                +
+                         }                                   +
+                     }                                       +
+                 },                                          +
+                 "description": "OK"                         +
+             }                                               +
+         },                                                  +
+         "description": "OpenAPI description (this document)"+
+     }                                                       +
+ }
+(1 row)
+
+-- Tables
+-- GET operation object
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'tags');
+  jsonb_pretty  
+----------------
+ [             +
+     "products"+
+ ]
+(1 row)
+
+  
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'200');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/get.products",+
+     "description": "OK"                           +
+ }
+(1 row)
+
+-- uses a reference for the 206 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'206');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/get.products",+
+     "description": "Partial Content"              +
+ }
+(1 row)
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'default');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/defaultError",+
+     "description": "Error"                        +
+ }
+(1 row)
+
+-- uses references for columns as query parameters
+select value 
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.products.%';
+                               value                                
+--------------------------------------------------------------------
+ {"$ref": "#/components/parameters/rowFilter.products.id"}
+ {"$ref": "#/components/parameters/rowFilter.products.code"}
+ {"$ref": "#/components/parameters/rowFilter.products.name"}
+ {"$ref": "#/components/parameters/rowFilter.products.description"}
+ {"$ref": "#/components/parameters/rowFilter.products.attr"}
+ {"$ref": "#/components/parameters/rowFilter.products.size"}
+(6 rows)
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
+                     value                     
+-----------------------------------------------
+ {"$ref": "#/components/parameters/select"}
+ {"$ref": "#/components/parameters/order"}
+ {"$ref": "#/components/parameters/limit"}
+ {"$ref": "#/components/parameters/offset"}
+ {"$ref": "#/components/parameters/or"}
+ {"$ref": "#/components/parameters/and"}
+ {"$ref": "#/components/parameters/not.or"}
+ {"$ref": "#/components/parameters/not.and"}
+ {"$ref": "#/components/parameters/range"}
+ {"$ref": "#/components/parameters/preferGet"}
+(10 rows)
+
+-- Views
+-- GET operation object
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'tags');
+    jsonb_pretty    
+--------------------
+ [                 +
+     "big_products"+
+ ]
+(1 row)
+
+  
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'200');
+                      jsonb_pretty                      
+--------------------------------------------------------
+ {                                                     +
+     "$ref": "#/components/responses/get.big_products",+
+     "description": "OK"                               +
+ }
+(1 row)
+
+-- uses a reference for the 206 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'206');
+                      jsonb_pretty                      
+--------------------------------------------------------
+ {                                                     +
+     "$ref": "#/components/responses/get.big_products",+
+     "description": "Partial Content"                  +
+ }
+(1 row)
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'default');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/defaultError",+
+     "description": "Error"                        +
+ }
+(1 row)
+
+-- uses references for columns as query parameters
+select value 
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
+                              value                              
+-----------------------------------------------------------------
+ {"$ref": "#/components/parameters/rowFilter.big_products.id"}
+ {"$ref": "#/components/parameters/rowFilter.big_products.code"}
+ {"$ref": "#/components/parameters/rowFilter.big_products.name"}
+ {"$ref": "#/components/parameters/rowFilter.big_products.size"}
+(4 rows)
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%';
+                     value                     
+-----------------------------------------------
+ {"$ref": "#/components/parameters/select"}
+ {"$ref": "#/components/parameters/order"}
+ {"$ref": "#/components/parameters/limit"}
+ {"$ref": "#/components/parameters/offset"}
+ {"$ref": "#/components/parameters/or"}
+ {"$ref": "#/components/parameters/and"}
+ {"$ref": "#/components/parameters/not.or"}
+ {"$ref": "#/components/parameters/not.and"}
+ {"$ref": "#/components/parameters/range"}
+ {"$ref": "#/components/parameters/preferGet"}
+(10 rows)
+

--- a/test/expected/responses.out
+++ b/test/expected/responses.out
@@ -1,0 +1,129 @@
+-- defines a default error response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
+                jsonb_pretty                
+--------------------------------------------
+ {                                         +
+     "content": {                          +
+         "application/json": {             +
+             "schema": {                   +
+                 "type": "object",         +
+                 "properties": {           +
+                     "code": {             +
+                         "type": "string"  +
+                     },                    +
+                     "hint": {             +
+                         "type": "string"  +
+                     },                    +
+                     "details": {          +
+                         "type": "string"  +
+                     },                    +
+                     "message": {          +
+                         "type": "string"  +
+                     }                     +
+                 }                         +
+             }                             +
+         }                                 +
+     },                                    +
+     "description": "Default error reponse"+
+ }
+(1 row)
+
+-- Tables
+-- GET operation object
+-- defines an application/json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
+                    jsonb_pretty                     
+-----------------------------------------------------
+ {                                                  +
+     "schema": {                                    +
+         "type": "array",                           +
+         "items": {                                 +
+             "$ref": "#/components/schemas/products"+
+         }                                          +
+     }                                              +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
+                  jsonb_pretty                   
+-------------------------------------------------
+ {                                              +
+     "schema": {                                +
+         "$ref": "#/components/schemas/products"+
+     }                                          +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+                  jsonb_pretty                   
+-------------------------------------------------
+ {                                              +
+     "schema": {                                +
+         "$ref": "#/components/schemas/products"+
+     }                                          +
+ }
+(1 row)
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
+       jsonb_pretty        
+---------------------------
+ {                        +
+     "schema": {          +
+         "type": "string",+
+         "format": "csv"  +
+     }                    +
+ }
+(1 row)
+
+-- Views
+-- GET operation object
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
+                      jsonb_pretty                       
+---------------------------------------------------------
+ {                                                      +
+     "schema": {                                        +
+         "type": "array",                               +
+         "items": {                                     +
+             "$ref": "#/components/schemas/big_products"+
+         }                                              +
+     }                                                  +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
+                    jsonb_pretty                     
+-----------------------------------------------------
+ {                                                  +
+     "schema": {                                    +
+         "$ref": "#/components/schemas/big_products"+
+     }                                              +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+                    jsonb_pretty                     
+-----------------------------------------------------
+ {                                                  +
+     "schema": {                                    +
+         "$ref": "#/components/schemas/big_products"+
+     }                                              +
+ }
+(1 row)
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
+       jsonb_pretty        
+---------------------------
+ {                        +
+     "schema": {          +
+         "type": "string",+
+         "format": "csv"  +
+     }                    +
+ }
+(1 row)
+

--- a/test/expected/schemas.out
+++ b/test/expected/schemas.out
@@ -287,7 +287,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 
 -- defines all the available prefer headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'schemas')
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'schemas')
 where key like 'header.prefer%';
            key            |                               jsonb_pretty                               
 --------------------------+--------------------------------------------------------------------------

--- a/test/expected/security.out
+++ b/test/expected/security.out
@@ -11,7 +11,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'securit
 (1 row)
 
 -- lists the JWT scheme as a security requirement object 
-select get_postgrest_openapi_spec('{public}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;
+select get_postgrest_openapi_spec('{test}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;
  has_jwt 
 ---------
  t

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -72,6 +72,11 @@ CREATE TABLE test.openapi_types(
   "a_jsonb_arr" jsonb[]
 );
 
+create view test.big_products as
+  select id, code, name, size
+  from test.products
+  where size in ('L', 'XL');
+
 create schema private;
 
 create table private.secret_table (

--- a/test/sql/parameters.sql
+++ b/test/sql/parameters.sql
@@ -7,3 +7,13 @@ where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'o
 select key, jsonb_pretty(value)
 from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDelete', 'preferPostRpc', 'range');
+
+-- shows table columns as parameters
+select key, jsonb_pretty(value)
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+where key like 'rowFilter.products.%';
+
+-- shows view columns as parameters
+select key, jsonb_pretty(value)
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+where key like 'rowFilter.big_products.%';

--- a/test/sql/parameters.sql
+++ b/test/sql/parameters.sql
@@ -1,9 +1,9 @@
 -- shows common query parameters
 select *
-from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'parameters')
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'or', 'and', 'not.or', 'not.and');
 
 -- shows common headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'parameters')
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDelete', 'preferPostRpc', 'range');

--- a/test/sql/paths.sql
+++ b/test/sql/paths.sql
@@ -1,0 +1,52 @@
+-- shows root path for the OpenAPI output
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/');
+
+-- Tables
+-- GET operation object
+
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'tags');
+  
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'200');
+
+-- uses a reference for the 206 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'206');
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'default');
+
+-- uses references for columns as query parameters
+select value 
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.products.%';
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
+
+-- Views
+-- GET operation object
+
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'tags');
+  
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'200');
+
+-- uses a reference for the 206 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'206');
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'default');
+
+-- uses references for columns as query parameters
+select value 
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%';

--- a/test/sql/responses.sql
+++ b/test/sql/responses.sql
@@ -1,0 +1,31 @@
+-- defines a default error response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
+
+-- Tables
+-- GET operation object
+
+-- defines an application/json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
+
+-- Views
+-- GET operation object
+
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');

--- a/test/sql/schemas.sql
+++ b/test/sql/schemas.sql
@@ -48,5 +48,5 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 
 -- defines all the available prefer headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{public}')->'components'->'schemas')
+from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'schemas')
 where key like 'header.prefer%';

--- a/test/sql/security.sql
+++ b/test/sql/security.sql
@@ -2,4 +2,4 @@
 select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'securitySchemes'->'JWT');
 
 -- lists the JWT scheme as a security requirement object 
-select get_postgrest_openapi_spec('{public}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;
+select get_postgrest_openapi_spec('{test}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;


### PR DESCRIPTION
The get requests for each path will have:
- Reference to common parameters (headers, query string)
- Unique query parameters for each table column