### PR TITLE
Add POST requests for tables and views 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ SQL functions to build the OpenAPI output of a PostgREST instance.
   - [ ] Paths object
     - [ ] Tables and Views
       - [x] GET
-      - [ ] POST
+      - [x] POST
       - [ ] PUT
       - [ ] DELETE
     - [ ] Functions

--- a/sql/main.sql
+++ b/sql/main.sql
@@ -4,7 +4,7 @@
 create or replace function callable_root() returns jsonb as $$
   -- Calling this every time is inefficient, but it's the best we can do until PostgREST calls it when it updates the server config
   CALL set_server_from_configuration();
-  SELECT get_postgrest_openapi_spec(
+  SELECT postgrest_openapi_spec(
     schemas := string_to_array(current_setting('pgrst.db_schemas', TRUE), ','),
     postgrest_version := current_setting('pgrst.version', TRUE),
     proa_version := '0.1'::text, -- TODO: needs to be updated; put into config, and have Makefile update
@@ -13,7 +13,7 @@ create or replace function callable_root() returns jsonb as $$
 $$ language sql;
 
 -- This one returns the OpenAPI JSON; instead of calling it directly, call "callable_root", below
-create or replace function get_postgrest_openapi_spec(
+create or replace function postgrest_openapi_spec(
   schemas text[],
   postgrest_version text default null,
   proa_version text default null,

--- a/sql/openapi.sql
+++ b/sql/openapi.sql
@@ -362,3 +362,17 @@ $$
     'encoding', encoding
   )
 $$;
+
+create or replace function oas_request_body_object(
+  content jsonb,
+  description text default null,
+  required boolean default null
+)
+returns jsonb language sql as
+$$
+  select json_build_object(
+    'content', content,
+    'description', description,
+    'required', required
+  )
+$$;

--- a/sql/postgrest.sql
+++ b/sql/postgrest.sql
@@ -17,7 +17,7 @@ returns table (
   required_cols text[],
   all_cols text[],
   columns jsonb
-) language sql as
+) language sql stable as
 $$
 WITH
   columns AS (

--- a/sql/utils.sql
+++ b/sql/utils.sql
@@ -29,6 +29,14 @@ $$
   );
 $$;
 
+create or replace function oas_build_reference_to_request_bodies(req_body text)
+returns jsonb language sql immutable as
+$$
+  select oas_reference_object(
+    ref := '#/components/requestBodies/' || req_body
+  );
+$$;
+
 create or replace function oas_build_reference_to_responses(response text, descrip text default null)
 returns jsonb language sql immutable as
 $$

--- a/test/expected/info.out
+++ b/test/expected/info.out
@@ -1,12 +1,12 @@
 -- shows the first line of the comment on the schema as title
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'info'->'title');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'info'->'title');
   jsonb_pretty  
 ----------------
  "My API title"
 (1 row)
 
 -- shows the second line of the comment on the schema as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'info'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'info'->'description');
                    jsonb_pretty                   
 --------------------------------------------------
  "My API description\nthat spans\nmultiple lines"

--- a/test/expected/main.out
+++ b/test/expected/main.out
@@ -20,8 +20,8 @@ SELECT string_to_array(current_setting('pgrst.db_schemas', TRUE), ',');
  {test}
 (1 row)
 
--- Tests get_postgrest_openapi_spec with parameters
-SELECT count(get_postgrest_openapi_spec(
+-- Tests postgrest_openapi_spec with parameters
+SELECT count(postgrest_openapi_spec(
   schemas := string_to_array(current_setting('pgrst.db_schemas', TRUE), ','),
   postgrest_version := current_setting('pgrst.version', TRUE),
   proa_version := '0.1'::text, -- TODO: needs to be updated; put into config, and have Makefile update

--- a/test/expected/parameters.out
+++ b/test/expected/parameters.out
@@ -1,6 +1,6 @@
 -- shows common query parameters
 select *
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'or', 'and', 'not.or', 'not.and');
      key     |                                                                                     value                                                                                     
 -------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'o
 
 -- shows common headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDelete', 'preferPostRpc', 'range');
       key      |                                 jsonb_pretty                                 
 ---------------+------------------------------------------------------------------------------
@@ -283,7 +283,7 @@ where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDele
 
 -- shows table columns as parameters
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key like 'rowFilter.products.%';
               key               |        jsonb_pretty        
 --------------------------------+----------------------------
@@ -333,7 +333,7 @@ where key like 'rowFilter.products.%';
 
 -- shows view columns as parameters
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key like 'rowFilter.big_products.%';
              key             |       jsonb_pretty       
 -----------------------------+--------------------------

--- a/test/expected/paths.out
+++ b/test/expected/paths.out
@@ -103,6 +103,54 @@ where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
  {"$ref": "#/components/parameters/preferGet"}
 (10 rows)
 
+-- POST operation object
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'tags');
+  jsonb_pretty  
+----------------
+ [             +
+     "products"+
+ ]
+(1 row)
+
+-- uses a reference for the 201 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'201');
+                    jsonb_pretty                     
+-----------------------------------------------------
+ {                                                  +
+     "$ref": "#/components/responses/post.products",+
+     "description": "Created"                       +
+ }
+(1 row)
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'default');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/defaultError",+
+     "description": "Error"                        +
+ }
+(1 row)
+
+-- uses a reference for request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'requestBody'->'$ref');
+             jsonb_pretty              
+---------------------------------------
+ "#/components/requestBodies/products"
+(1 row)
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'parameters')
+where value->>'$ref' like '#/components/parameters/%';
+                     value                      
+------------------------------------------------
+ {"$ref": "#/components/parameters/select"}
+ {"$ref": "#/components/parameters/columns"}
+ {"$ref": "#/components/parameters/preferPost"}
+(3 rows)
+
 -- Views
 -- GET operation object
 -- shows the table name as tag
@@ -174,4 +222,66 @@ where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%'
  {"$ref": "#/components/parameters/range"}
  {"$ref": "#/components/parameters/preferGet"}
 (10 rows)
+
+-- shows a GET operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'get' as value;
+ value 
+-------
+ t
+(1 row)
+
+-- POST operation object
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'tags');
+    jsonb_pretty    
+--------------------
+ [                 +
+     "big_products"+
+ ]
+(1 row)
+
+-- uses a reference for the 201 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'201');
+                      jsonb_pretty                       
+---------------------------------------------------------
+ {                                                      +
+     "$ref": "#/components/responses/post.big_products",+
+     "description": "Created"                           +
+ }
+(1 row)
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'default');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/defaultError",+
+     "description": "Error"                        +
+ }
+(1 row)
+
+-- uses a reference for request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'requestBody'->'$ref');
+               jsonb_pretty                
+-------------------------------------------
+ "#/components/requestBodies/big_products"
+(1 row)
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'parameters')
+where value->>'$ref' like '#/components/parameters/%';
+                     value                      
+------------------------------------------------
+ {"$ref": "#/components/parameters/select"}
+ {"$ref": "#/components/parameters/columns"}
+ {"$ref": "#/components/parameters/preferPost"}
+(3 rows)
+
+-- does not show a POST operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;
+ value 
+-------
+ f
+(1 row)
 

--- a/test/expected/paths.out
+++ b/test/expected/paths.out
@@ -1,5 +1,5 @@
 -- shows root path for the OpenAPI output
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/');
                          jsonb_pretty                         
 --------------------------------------------------------------
  {                                                           +
@@ -32,7 +32,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/');
 -- Tables
 -- GET operation object
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'tags');
   jsonb_pretty  
 ----------------
  [             +
@@ -42,7 +42,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 
   
 -- uses a reference for the 200 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'200');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'200');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -52,7 +52,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 (1 row)
 
 -- uses a reference for the 206 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'206');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'206');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -62,7 +62,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 (1 row)
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'default');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -73,7 +73,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 
 -- uses references for columns as query parameters
 select value 
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
 where value->>'$ref' like '#/components/parameters/rowFilter.products.%';
                                value                                
 --------------------------------------------------------------------
@@ -87,7 +87,7 @@ where value->>'$ref' like '#/components/parameters/rowFilter.products.%';
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
 where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
                      value                     
 -----------------------------------------------
@@ -105,7 +105,7 @@ where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
 
 -- POST operation object
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'tags');
   jsonb_pretty  
 ----------------
  [             +
@@ -114,7 +114,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 (1 row)
 
 -- uses a reference for the 201 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'201');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'201');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -124,7 +124,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 (1 row)
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'default');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -134,7 +134,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 (1 row)
 
 -- uses a reference for request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'requestBody'->'$ref');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'requestBody'->'$ref');
              jsonb_pretty              
 ---------------------------------------
  "#/components/requestBodies/products"
@@ -142,7 +142,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'parameters')
 where value->>'$ref' like '#/components/parameters/%';
                      value                      
 ------------------------------------------------
@@ -154,7 +154,7 @@ where value->>'$ref' like '#/components/parameters/%';
 -- Views
 -- GET operation object
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'tags');
     jsonb_pretty    
 --------------------
  [                 +
@@ -164,7 +164,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 
   
 -- uses a reference for the 200 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'200');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'200');
                       jsonb_pretty                      
 --------------------------------------------------------
  {                                                     +
@@ -174,7 +174,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 (1 row)
 
 -- uses a reference for the 206 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'206');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'206');
                       jsonb_pretty                      
 --------------------------------------------------------
  {                                                     +
@@ -184,7 +184,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 (1 row)
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'default');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -195,7 +195,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 
 -- uses references for columns as query parameters
 select value 
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
 where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
                               value                              
 -----------------------------------------------------------------
@@ -207,7 +207,7 @@ where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
 where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%';
                      value                     
 -----------------------------------------------
@@ -224,7 +224,7 @@ where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%'
 (10 rows)
 
 -- shows a GET operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'get' as value;
+select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'get' as value;
  value 
 -------
  t
@@ -232,7 +232,7 @@ select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'g
 
 -- POST operation object
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'tags');
     jsonb_pretty    
 --------------------
  [                 +
@@ -241,7 +241,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 (1 row)
 
 -- uses a reference for the 201 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'201');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'201');
                       jsonb_pretty                       
 ---------------------------------------------------------
  {                                                      +
@@ -251,7 +251,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 (1 row)
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'default');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -261,7 +261,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 (1 row)
 
 -- uses a reference for request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'requestBody'->'$ref');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'requestBody'->'$ref');
                jsonb_pretty                
 -------------------------------------------
  "#/components/requestBodies/big_products"
@@ -269,7 +269,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_product
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'parameters')
 where value->>'$ref' like '#/components/parameters/%';
                      value                      
 ------------------------------------------------
@@ -279,7 +279,7 @@ where value->>'$ref' like '#/components/parameters/%';
 (3 rows)
 
 -- does not show a POST operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;
+select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;
  value 
 -------
  f

--- a/test/expected/reqbodies.out
+++ b/test/expected/reqbodies.out
@@ -1,6 +1,6 @@
 -- Tables
 -- defines an application/json request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/json');
                         jsonb_pretty                         
 -------------------------------------------------------------
  {                                                          +
@@ -21,7 +21,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'request
 (1 row)
 
 -- defines an application/x-www-form-urlencoded request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/x-www-form-urlencoded');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/x-www-form-urlencoded');
                   jsonb_pretty                   
 -------------------------------------------------
  {                                              +
@@ -32,7 +32,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'request
 (1 row)
 
 -- defines a text/csv request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -45,7 +45,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'request
 
 -- Views
 -- defines an application/json request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/json');
                           jsonb_pretty                           
 -----------------------------------------------------------------
  {                                                              +
@@ -66,7 +66,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'request
 (1 row)
 
 -- defines an application/x-www-form-urlencoded request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/x-www-form-urlencoded');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/x-www-form-urlencoded');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -77,7 +77,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'request
 (1 row)
 
 -- defines a text/csv request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -89,7 +89,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'request
 (1 row)
 
 -- does not define a request body for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'components'->'requestBodies' ? 'non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'requestBodies' ? 'non_auto_updatable' as value;
  value 
 -------
  f

--- a/test/expected/reqbodies.out
+++ b/test/expected/reqbodies.out
@@ -1,0 +1,97 @@
+-- Tables
+-- defines an application/json request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/json');
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "schema": {                                            +
+         "oneOf": [                                         +
+             {                                              +
+                 "$ref": "#/components/schemas/products"    +
+             },                                             +
+             {                                              +
+                 "type": "array",                           +
+                 "items": {                                 +
+                     "$ref": "#/components/schemas/products"+
+                 }                                          +
+             }                                              +
+         ]                                                  +
+     }                                                      +
+ }
+(1 row)
+
+-- defines an application/x-www-form-urlencoded request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/x-www-form-urlencoded');
+                  jsonb_pretty                   
+-------------------------------------------------
+ {                                              +
+     "schema": {                                +
+         "$ref": "#/components/schemas/products"+
+     }                                          +
+ }
+(1 row)
+
+-- defines a text/csv request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'text/csv');
+       jsonb_pretty        
+---------------------------
+ {                        +
+     "schema": {          +
+         "type": "string",+
+         "format": "csv"  +
+     }                    +
+ }
+(1 row)
+
+-- Views
+-- defines an application/json request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/json');
+                          jsonb_pretty                           
+-----------------------------------------------------------------
+ {                                                              +
+     "schema": {                                                +
+         "oneOf": [                                             +
+             {                                                  +
+                 "$ref": "#/components/schemas/big_products"    +
+             },                                                 +
+             {                                                  +
+                 "type": "array",                               +
+                 "items": {                                     +
+                     "$ref": "#/components/schemas/big_products"+
+                 }                                              +
+             }                                                  +
+         ]                                                      +
+     }                                                          +
+ }
+(1 row)
+
+-- defines an application/x-www-form-urlencoded request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/x-www-form-urlencoded');
+                    jsonb_pretty                     
+-----------------------------------------------------
+ {                                                  +
+     "schema": {                                    +
+         "$ref": "#/components/schemas/big_products"+
+     }                                              +
+ }
+(1 row)
+
+-- defines a text/csv request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'text/csv');
+       jsonb_pretty        
+---------------------------
+ {                        +
+     "schema": {          +
+         "type": "string",+
+         "format": "csv"  +
+     }                    +
+ }
+(1 row)
+
+-- does not define a request body for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'components'->'requestBodies' ? 'non_auto_updatable' as value;
+ value 
+-------
+ f
+(1 row)
+

--- a/test/expected/responses.out
+++ b/test/expected/responses.out
@@ -78,6 +78,76 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
  }
 (1 row)
 
+-- POST operation object
+-- defines an application/json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "schema": {                                            +
+         "oneOf": [                                         +
+             {                                              +
+                 "type": "array",                           +
+                 "items": {                                 +
+                     "$ref": "#/components/schemas/products"+
+                 }                                          +
+             },                                             +
+             {                                              +
+                 "type": "string"                           +
+             }                                              +
+         ]                                                  +
+     }                                                      +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
+                      jsonb_pretty                       
+---------------------------------------------------------
+ {                                                      +
+     "schema": {                                        +
+         "oneOf": [                                     +
+             {                                          +
+                 "$ref": "#/components/schemas/products"+
+             },                                         +
+             {                                          +
+                 "type": "string"                       +
+             }                                          +
+         ]                                              +
+     }                                                  +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+                      jsonb_pretty                       
+---------------------------------------------------------
+ {                                                      +
+     "schema": {                                        +
+         "oneOf": [                                     +
+             {                                          +
+                 "$ref": "#/components/schemas/products"+
+             },                                         +
+             {                                          +
+                 "type": "string"                       +
+             }                                          +
+         ]                                              +
+     }                                                  +
+ }
+(1 row)
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
+       jsonb_pretty        
+---------------------------
+ {                        +
+     "schema": {          +
+         "type": "string",+
+         "format": "csv"  +
+     }                    +
+ }
+(1 row)
+
 -- Views
 -- GET operation object
 select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
@@ -125,5 +195,89 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
          "format": "csv"  +
      }                    +
  }
+(1 row)
+
+-- defines a GET operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
+ value 
+-------
+ t
+(1 row)
+
+-- POST operation object
+-- defines an application/json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
+                          jsonb_pretty                           
+-----------------------------------------------------------------
+ {                                                              +
+     "schema": {                                                +
+         "oneOf": [                                             +
+             {                                                  +
+                 "type": "array",                               +
+                 "items": {                                     +
+                     "$ref": "#/components/schemas/big_products"+
+                 }                                              +
+             },                                                 +
+             {                                                  +
+                 "type": "string"                               +
+             }                                                  +
+         ]                                                      +
+     }                                                          +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "schema": {                                            +
+         "oneOf": [                                         +
+             {                                              +
+                 "$ref": "#/components/schemas/big_products"+
+             },                                             +
+             {                                              +
+                 "type": "string"                           +
+             }                                              +
+         ]                                                  +
+     }                                                      +
+ }
+(1 row)
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "schema": {                                            +
+         "oneOf": [                                         +
+             {                                              +
+                 "$ref": "#/components/schemas/big_products"+
+             },                                             +
+             {                                              +
+                 "type": "string"                           +
+             }                                              +
+         ]                                                  +
+     }                                                      +
+ }
+(1 row)
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
+       jsonb_pretty        
+---------------------------
+ {                        +
+     "schema": {          +
+         "type": "string",+
+         "format": "csv"  +
+     }                    +
+ }
+(1 row)
+
+-- does not define a POST operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;
+ value 
+-------
+ f
 (1 row)
 

--- a/test/expected/responses.out
+++ b/test/expected/responses.out
@@ -1,5 +1,5 @@
 -- defines a default error response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
                 jsonb_pretty                
 --------------------------------------------
  {                                         +
@@ -31,7 +31,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 -- Tables
 -- GET operation object
 -- defines an application/json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -45,7 +45,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
                   jsonb_pretty                   
 -------------------------------------------------
  {                                              +
@@ -56,7 +56,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                   jsonb_pretty                   
 -------------------------------------------------
  {                                              +
@@ -67,7 +67,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -80,7 +80,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 
 -- POST operation object
 -- defines an application/json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
                         jsonb_pretty                         
 -------------------------------------------------------------
  {                                                          +
@@ -101,7 +101,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
                       jsonb_pretty                       
 ---------------------------------------------------------
  {                                                      +
@@ -119,7 +119,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                       jsonb_pretty                       
 ---------------------------------------------------------
  {                                                      +
@@ -137,7 +137,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -150,7 +150,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 
 -- Views
 -- GET operation object
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
                       jsonb_pretty                       
 ---------------------------------------------------------
  {                                                      +
@@ -164,7 +164,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -175,7 +175,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -186,7 +186,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -198,7 +198,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines a GET operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
  value 
 -------
  t
@@ -206,7 +206,7 @@ select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.no
 
 -- POST operation object
 -- defines an application/json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
                           jsonb_pretty                           
 -----------------------------------------------------------------
  {                                                              +
@@ -227,7 +227,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
                         jsonb_pretty                         
 -------------------------------------------------------------
  {                                                          +
@@ -245,7 +245,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                         jsonb_pretty                         
 -------------------------------------------------------------
  {                                                          +
@@ -263,7 +263,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -275,7 +275,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 (1 row)
 
 -- does not define a POST operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;
  value 
 -------
  f

--- a/test/expected/schemas.out
+++ b/test/expected/schemas.out
@@ -1,12 +1,12 @@
 -- detects tables as objects
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'type');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'type');
  jsonb_pretty 
 --------------
  "object"
 (1 row)
 
 -- detects columns with enum types as an enum property
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'size');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'size');
         jsonb_pretty        
 ----------------------------
  {                         +
@@ -23,7 +23,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 (1 row)
 
 -- references a composite type column from a table to a component definition
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'attr');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'attr');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -32,7 +32,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 (1 row)
 
 -- identifies the required columns
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'required');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'required');
    jsonb_pretty    
 -------------------
  [                +
@@ -44,21 +44,21 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 (1 row)
 
 -- detects comments done on a table and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'description');
                               jsonb_pretty                               
 -------------------------------------------------------------------------
  "Products summary\n\nProducts description\nthat spans\nmultiple lines."
 (1 row)
 
 -- detects comments done on a table column and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'id'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'id'->'description');
        jsonb_pretty        
 ---------------------------
  "identifier of a product"
 (1 row)
 
 -- maps sql types to OpenAPI types correctly
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'openapi_types');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'openapi_types');
                  jsonb_pretty                  
 -----------------------------------------------
  {                                            +
@@ -190,21 +190,21 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 (1 row)
 
 -- does not show tables outside the exposed schema
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'secret_table');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'secret_table');
  jsonb_pretty 
 --------------
  
 (1 row)
 
 -- detects composite types as objects
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'type');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'type');
  jsonb_pretty 
 --------------
  "object"
 (1 row)
 
 -- references a composite type column from another composite type to a component definition
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'dim');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'dim');
                     jsonb_pretty                    
 ----------------------------------------------------
  {                                                 +
@@ -213,7 +213,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 (1 row)
 
 -- detects a composite type inside another composite type
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension');
           jsonb_pretty           
 ---------------------------------
  {                              +
@@ -236,7 +236,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 (1 row)
 
 -- detects an array composite type inside another composite type
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color');
             jsonb_pretty            
 ------------------------------------
  {                                 +
@@ -256,28 +256,28 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 (1 row)
 
 -- does not show a composite type that is not used by an exposed table
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.hiddentype');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.hiddentype');
  jsonb_pretty 
 --------------
  
 (1 row)
 
 -- detects comments done on a composite type and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'description');
                                jsonb_pretty                                
 ---------------------------------------------------------------------------
  "Attribute summary\n\nAttribute description\nthat spans\nmultiple lines."
 (1 row)
 
 -- detects comments done on a composite type column and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'other'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'other'->'description');
               jsonb_pretty               
 -----------------------------------------
  "other information about the attribute"
 (1 row)
 
 -- references a composite type column from an array composite type inside the items property
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'colors'->'items');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'colors'->'items');
                   jsonb_pretty                  
 ------------------------------------------------
  {                                             +
@@ -287,7 +287,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas
 
 -- defines all the available prefer headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'schemas')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'schemas')
 where key like 'header.prefer%';
            key            |                               jsonb_pretty                               
 --------------------------+--------------------------------------------------------------------------

--- a/test/expected/security.out
+++ b/test/expected/security.out
@@ -1,5 +1,5 @@
 -- shows the JWT security scheme
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'securitySchemes'->'JWT');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'securitySchemes'->'JWT');
                                         jsonb_pretty                                        
 --------------------------------------------------------------------------------------------
  {                                                                                         +
@@ -11,7 +11,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'securit
 (1 row)
 
 -- lists the JWT scheme as a security requirement object 
-select get_postgrest_openapi_spec('{test}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;
+select postgrest_openapi_spec('{test}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;
  has_jwt 
 ---------
  t

--- a/test/expected/servers.out
+++ b/test/expected/servers.out
@@ -1,6 +1,6 @@
 -- shows the default server
 DELETE FROM servers WHERE slug = 'default' and priority = 20;
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
               jsonb_pretty              
 ----------------------------------------
  [                                     +
@@ -21,7 +21,7 @@ SELECT postgrest.pre_config();
 -- Sets the config; would be called if we called callable_root() (in main)
 CALL set_server_from_configuration();
 -- shows the custom server url specified in the configuration
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
                   jsonb_pretty                   
 -------------------------------------------------
  [                                              +
@@ -34,7 +34,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
 
 -- shows the overriding custom server url specified by the user
 INSERT INTO servers (url, description, priority) VALUES ('https://www.example.com/api/', 'Overriding URL', 30);
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
                   jsonb_pretty                  
 ------------------------------------------------
  [                                             +
@@ -48,7 +48,7 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
 -- shows the additional custom server url specified by the user
 INSERT INTO servers (url, description, priority, slug, variables)
   VALUES ('https://www.example.com/otherapi/?s={s}&browser={browser}', 'Additional URL', 30, 'additional', '{"s": "worms", "browser": "none"}');
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
                                 jsonb_pretty                                 
 -----------------------------------------------------------------------------
  [                                                                          +

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -77,6 +77,9 @@ create view test.big_products as
   from test.products
   where size in ('L', 'XL');
 
+create view test.non_auto_updatable as
+  select 'this view is not auto updatable' as description;
+
 create schema private;
 
 create table private.secret_table (

--- a/test/sql/info.sql
+++ b/test/sql/info.sql
@@ -1,7 +1,7 @@
 -- shows the first line of the comment on the schema as title
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'info'->'title');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'info'->'title');
 
 -- shows the second line of the comment on the schema as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'info'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'info'->'description');
 
 -- TODO: tests for versions

--- a/test/sql/main.sql
+++ b/test/sql/main.sql
@@ -8,8 +8,8 @@ CALL set_server_from_configuration();
 SELECT current_setting('pgrst.db_schemas', TRUE);
 SELECT string_to_array(current_setting('pgrst.db_schemas', TRUE), ',');
 
--- Tests get_postgrest_openapi_spec with parameters
-SELECT count(get_postgrest_openapi_spec(
+-- Tests postgrest_openapi_spec with parameters
+SELECT count(postgrest_openapi_spec(
   schemas := string_to_array(current_setting('pgrst.db_schemas', TRUE), ','),
   postgrest_version := current_setting('pgrst.version', TRUE),
   proa_version := '0.1'::text, -- TODO: needs to be updated; put into config, and have Makefile update

--- a/test/sql/parameters.sql
+++ b/test/sql/parameters.sql
@@ -1,19 +1,19 @@
 -- shows common query parameters
 select *
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('select', 'order', 'limit', 'offset', 'on_conflict', 'columns', 'or', 'and', 'not.or', 'not.and');
 
 -- shows common headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key in ('preferGet', 'preferPost', 'preferPut', 'preferPatch', 'preferDelete', 'preferPostRpc', 'range');
 
 -- shows table columns as parameters
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key like 'rowFilter.products.%';
 
 -- shows view columns as parameters
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'parameters')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'parameters')
 where key like 'rowFilter.big_products.%';

--- a/test/sql/paths.sql
+++ b/test/sql/paths.sql
@@ -26,6 +26,25 @@ select value
 from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
 where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
 
+-- POST operation object
+
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'tags');
+
+-- uses a reference for the 201 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'201');
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'default');
+
+-- uses a reference for request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'requestBody'->'$ref');
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'parameters')
+where value->>'$ref' like '#/components/parameters/%';
+
 -- Views
 -- GET operation object
 
@@ -50,3 +69,28 @@ where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
 select value
 from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
 where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%';
+
+-- shows a GET operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'get' as value;
+
+-- POST operation object
+
+-- shows the table name as tag
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'tags');
+
+-- uses a reference for the 201 HTTP code response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'201');
+
+-- uses a reference for error responses
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'default');
+
+-- uses a reference for request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'requestBody'->'$ref');
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'parameters')
+where value->>'$ref' like '#/components/parameters/%';
+
+-- does not show a POST operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;

--- a/test/sql/paths.sql
+++ b/test/sql/paths.sql
@@ -1,96 +1,96 @@
 -- shows root path for the OpenAPI output
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/');
 
 -- Tables
 -- GET operation object
 
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'tags');
   
 -- uses a reference for the 200 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'200');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'200');
 
 -- uses a reference for the 206 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'206');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'206');
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'default');
 
 -- uses references for columns as query parameters
 select value 
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
 where value->>'$ref' like '#/components/parameters/rowFilter.products.%';
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'parameters')
 where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
 
 -- POST operation object
 
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'tags');
 
 -- uses a reference for the 201 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'201');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'201');
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'default');
 
 -- uses a reference for request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'requestBody'->'$ref');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'requestBody'->'$ref');
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'parameters')
 where value->>'$ref' like '#/components/parameters/%';
 
 -- Views
 -- GET operation object
 
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'tags');
   
 -- uses a reference for the 200 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'200');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'200');
 
 -- uses a reference for the 206 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'206');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'206');
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'default');
 
 -- uses references for columns as query parameters
 select value 
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
 where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'parameters')
 where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%';
 
 -- shows a GET operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'get' as value;
+select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'get' as value;
 
 -- POST operation object
 
 -- shows the table name as tag
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'tags');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'tags');
 
 -- uses a reference for the 201 HTTP code response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'201');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'201');
 
 -- uses a reference for error responses
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'default');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'default');
 
 -- uses a reference for request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'requestBody'->'$ref');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'requestBody'->'$ref');
 
 -- uses references for common parameters
 select value
-from jsonb_array_elements(get_postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'parameters')
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'parameters')
 where value->>'$ref' like '#/components/parameters/%';
 
 -- does not show a POST operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;
+select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;

--- a/test/sql/reqbodies.sql
+++ b/test/sql/reqbodies.sql
@@ -1,24 +1,24 @@
 -- Tables
 
 -- defines an application/json request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/json');
 
 -- defines an application/x-www-form-urlencoded request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/x-www-form-urlencoded');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/x-www-form-urlencoded');
 
 -- defines a text/csv request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'text/csv');
 
 -- Views
 
 -- defines an application/json request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/json');
 
 -- defines an application/x-www-form-urlencoded request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/x-www-form-urlencoded');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/x-www-form-urlencoded');
 
 -- defines a text/csv request body
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'text/csv');
 
 -- does not define a request body for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'components'->'requestBodies' ? 'non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'requestBodies' ? 'non_auto_updatable' as value;

--- a/test/sql/reqbodies.sql
+++ b/test/sql/reqbodies.sql
@@ -1,0 +1,24 @@
+-- Tables
+
+-- defines an application/json request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/json');
+
+-- defines an application/x-www-form-urlencoded request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'application/x-www-form-urlencoded');
+
+-- defines a text/csv request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'products'->'content'->'text/csv');
+
+-- Views
+
+-- defines an application/json request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/json');
+
+-- defines an application/x-www-form-urlencoded request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'application/x-www-form-urlencoded');
+
+-- defines a text/csv request body
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'requestBodies'->'big_products'->'content'->'text/csv');
+
+-- does not define a request body for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'components'->'requestBodies' ? 'non_auto_updatable' as value;

--- a/test/sql/responses.sql
+++ b/test/sql/responses.sql
@@ -1,65 +1,65 @@
 -- defines a default error response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
 
 -- Tables
 -- GET operation object
 
 -- defines an application/json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
 
 -- POST operation object
 
 -- defines an application/json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
 
 -- Views
 -- GET operation object
 
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
 
 -- defines a GET operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
 
 -- POST operation object
 
 -- defines an application/json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
 
 -- does not define a POST operation object for non auto-updatable views
-select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;

--- a/test/sql/responses.sql
+++ b/test/sql/responses.sql
@@ -16,6 +16,20 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 -- defines a text/csv response
 select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
 
+-- POST operation object
+
+-- defines an application/json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
+
 -- Views
 -- GET operation object
 
@@ -29,3 +43,23 @@ select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'respons
 
 -- defines a text/csv response
 select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
+
+-- defines a GET operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
+
+-- POST operation object
+
+-- defines an application/json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
+
+-- defines an application/vnd.pgrst.object+json response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
+
+-- defines an application/vnd.pgrst.object+json;nulls=stripped response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+
+-- defines a text/csv response
+select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
+
+-- does not define a POST operation object for non auto-updatable views
+select get_postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;

--- a/test/sql/schemas.sql
+++ b/test/sql/schemas.sql
@@ -1,52 +1,52 @@
 -- detects tables as objects
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'type');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'type');
 
 -- detects columns with enum types as an enum property
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'size');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'size');
 
 -- references a composite type column from a table to a component definition
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'attr');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'attr');
 
 -- identifies the required columns
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'required');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'required');
 
 -- detects comments done on a table and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'description');
 
 -- detects comments done on a table column and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'id'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'properties'->'id'->'description');
 
 -- maps sql types to OpenAPI types correctly
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'openapi_types');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'openapi_types');
 
 -- does not show tables outside the exposed schema
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'secret_table');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'secret_table');
 
 -- detects composite types as objects
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'type');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'type');
 
 -- references a composite type column from another composite type to a component definition
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'dim');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'dim');
 
 -- detects a composite type inside another composite type
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension');
 
 -- detects an array composite type inside another composite type
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color');
 
 -- does not show a composite type that is not used by an exposed table
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.hiddentype');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.hiddentype');
 
 -- detects comments done on a composite type and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'description');
 
 -- detects comments done on a composite type column and shows it as description
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'other'->'description');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'other'->'description');
 
 -- references a composite type column from an array composite type inside the items property
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'colors'->'items');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'colors'->'items');
 
 -- defines all the available prefer headers
 select key, jsonb_pretty(value)
-from jsonb_each(get_postgrest_openapi_spec('{test}')->'components'->'schemas')
+from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'schemas')
 where key like 'header.prefer%';

--- a/test/sql/security.sql
+++ b/test/sql/security.sql
@@ -1,5 +1,5 @@
 -- shows the JWT security scheme
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'components'->'securitySchemes'->'JWT');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'securitySchemes'->'JWT');
 
 -- lists the JWT scheme as a security requirement object 
-select get_postgrest_openapi_spec('{test}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;
+select postgrest_openapi_spec('{test}')->'security' <@ '[{"JWT": []}]'::jsonb as has_jwt;

--- a/test/sql/servers.sql
+++ b/test/sql/servers.sql
@@ -1,6 +1,6 @@
 -- shows the default server
 DELETE FROM servers WHERE slug = 'default' and priority = 20;
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
 
 -- Loads the config -- only needed because we're not using actual PostgREST in the tests
 SELECT postgrest.pre_config();
@@ -8,17 +8,17 @@ SELECT postgrest.pre_config();
 CALL set_server_from_configuration();
 
 -- shows the custom server url specified in the configuration
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
 
 
 -- shows the overriding custom server url specified by the user
 INSERT INTO servers (url, description, priority) VALUES ('https://www.example.com/api/', 'Overriding URL', 30);
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
 
 -- shows the additional custom server url specified by the user
 INSERT INTO servers (url, description, priority, slug, variables)
   VALUES ('https://www.example.com/otherapi/?s={s}&browser={browser}', 'Additional URL', 30, 'additional', '{"s": "worms", "browser": "none"}');
-select jsonb_pretty(get_postgrest_openapi_spec('{test}')->'servers');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'servers');
 
 -- Shows the configuration table
 SELECT * from servers;


### PR DESCRIPTION
Adds:
- POST requests to `paths` object for tables and views
- Request bodies in `components`, excluding non-updatable views
- Responses for created resources (`201` and default errors)