### PR TITLE
Adds PATCH requests for tables and views

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ SQL functions to build the OpenAPI output of a PostgREST instance.
     - [ ] Tables and Views
       - [x] GET
       - [x] POST
-      - [ ] PUT
+      - [x] PATCH
       - [ ] DELETE
     - [ ] Functions
       - [ ] GET

--- a/sql/components.sql
+++ b/sql/components.sql
@@ -535,12 +535,12 @@ $$;
 create or replace function oas_build_response_objects_from_tables(schemas text[])
 returns jsonb language sql as
 $$
-select jsonb_object_agg(x.get, x.get_response) ||
-       jsonb_object_agg(x.post, x.post_response)
+select jsonb_object_agg(x.not_empty, x.not_empty_response) ||
+       jsonb_object_agg(x.may_be_empty, x.may_be_empty_response)
 from (
-  select 'get.' || table_name as get,
+  select 'notEmpty.' || table_name as not_empty,
     oas_response_object(
-      description := 'GET media types for ' || table_name,
+      description := 'Media types when response body is not empty for ' || table_name,
       content := jsonb_build_object(
         'application/json',
         oas_media_type_object(
@@ -565,11 +565,11 @@ from (
           )
         )
       )
-    ) as get_response,
-    'post.' || table_name as post,
+    ) as not_empty_response,
+    'mayBeEmpty.' || table_name as may_be_empty,
     case when insertable then
       oas_response_object(
-        description := 'POST media types for ' || table_name,
+        description := 'Media types when response body could be empty or not for ' || table_name,
         content := jsonb_build_object(
           'application/json',
           oas_media_type_object(
@@ -616,7 +616,7 @@ from (
           )
         )
       )
-    end as post_response
+    end as may_be_empty_response
   from postgrest_get_all_tables(schemas)
   where table_schema = any(schemas)
 ) as x

--- a/sql/components.sql
+++ b/sql/components.sql
@@ -643,6 +643,11 @@ select jsonb_build_object(
         )
       )
     )
+  ),
+  'empty',
+  oas_response_object(
+    description := 'No media types when response body is empty'
+    -- Does not specify a "content": https://swagger.io/docs/specification/describing-responses/#empty
   )
 );
 $$;

--- a/sql/paths.sql
+++ b/sql/paths.sql
@@ -59,14 +59,44 @@ from (
               oas_build_reference_to_responses('defaultError', 'Error')
             )
           )
+        end,
+      patch :=
+        case when updatable then
+          oas_operation_object(
+            description := table_description,
+            tags := array[table_name],
+            requestBody := oas_build_reference_to_request_bodies(table_name),
+            parameters := jsonb_agg(
+              oas_build_reference_to_parameters(format('rowFilter.%1$s.%2$s', table_name, column_name))
+            ) ||
+            jsonb_build_array(
+              oas_build_reference_to_parameters('select'),
+              oas_build_reference_to_parameters('columns'),
+              oas_build_reference_to_parameters('order'),
+              oas_build_reference_to_parameters('limit'),
+              oas_build_reference_to_parameters('or'),
+              oas_build_reference_to_parameters('and'),
+              oas_build_reference_to_parameters('not.or'),
+              oas_build_reference_to_parameters('not.and'),
+              oas_build_reference_to_parameters('preferPatch')
+            ),
+            responses := jsonb_build_object(
+              '200',
+              oas_build_reference_to_responses('notEmpty.' || table_name, 'OK'),
+              '204',
+              oas_build_reference_to_responses('empty', 'No Content'),
+              'default',
+              oas_build_reference_to_responses('defaultError', 'Error')
+            )
+          )
         end
     ) as oas_path_item
   from (
-   select table_schema, table_name, table_description, insertable, unnest(all_cols) as column_name
+   select table_schema, table_name, table_description, insertable, updatable, unnest(all_cols) as column_name
    from postgrest_get_all_tables(schemas)
   ) _
   where table_schema = any(schemas)
-  group by table_schema, table_name, table_description, insertable
+  group by table_schema, table_name, table_description, insertable, updatable
 ) x;
 $$;
 

--- a/sql/paths.sql
+++ b/sql/paths.sql
@@ -34,9 +34,9 @@ from (
         ),
         responses := jsonb_build_object(
           '200',
-          oas_build_reference_to_responses('get.' || table_name, 'OK'),
+          oas_build_reference_to_responses('notEmpty.' || table_name, 'OK'),
           '206',
-          oas_build_reference_to_responses('get.' || table_name, 'Partial Content'),
+          oas_build_reference_to_responses('notEmpty.' || table_name, 'Partial Content'),
           'default',
           oas_build_reference_to_responses('defaultError', 'Error')
         )
@@ -54,7 +54,7 @@ from (
             ),
             responses := jsonb_build_object(
               '201',
-              oas_build_reference_to_responses('post.' || table_name, 'Created'),
+              oas_build_reference_to_responses('mayBeEmpty.' || table_name, 'Created'),
               'default',
               oas_build_reference_to_responses('defaultError', 'Error')
             )

--- a/test/expected/paths.out
+++ b/test/expected/paths.out
@@ -151,6 +151,77 @@ where value->>'$ref' like '#/components/parameters/%';
  {"$ref": "#/components/parameters/preferPost"}
 (3 rows)
 
+-- PATCH operation object
+-- shows the table name as tag
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'tags');
+  jsonb_pretty  
+----------------
+ [             +
+     "products"+
+ ]
+(1 row)
+
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'responses'->'200');
+                      jsonb_pretty                       
+---------------------------------------------------------
+ {                                                      +
+     "$ref": "#/components/responses/notEmpty.products",+
+     "description": "OK"                                +
+ }
+(1 row)
+
+-- uses a reference for the 204 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'responses'->'204');
+                jsonb_pretty                 
+---------------------------------------------
+ {                                          +
+     "$ref": "#/components/responses/empty",+
+     "description": "No Content"            +
+ }
+(1 row)
+
+-- uses a reference for error responses
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'responses'->'default');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/defaultError",+
+     "description": "Error"                        +
+ }
+(1 row)
+
+-- uses references for columns as query parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.products.%';
+                               value                                
+--------------------------------------------------------------------
+ {"$ref": "#/components/parameters/rowFilter.products.id"}
+ {"$ref": "#/components/parameters/rowFilter.products.code"}
+ {"$ref": "#/components/parameters/rowFilter.products.name"}
+ {"$ref": "#/components/parameters/rowFilter.products.description"}
+ {"$ref": "#/components/parameters/rowFilter.products.attr"}
+ {"$ref": "#/components/parameters/rowFilter.products.size"}
+(6 rows)
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
+                      value                      
+-------------------------------------------------
+ {"$ref": "#/components/parameters/select"}
+ {"$ref": "#/components/parameters/columns"}
+ {"$ref": "#/components/parameters/order"}
+ {"$ref": "#/components/parameters/limit"}
+ {"$ref": "#/components/parameters/or"}
+ {"$ref": "#/components/parameters/and"}
+ {"$ref": "#/components/parameters/not.or"}
+ {"$ref": "#/components/parameters/not.and"}
+ {"$ref": "#/components/parameters/preferPatch"}
+(9 rows)
+
 -- Views
 -- GET operation object
 -- shows the table name as tag
@@ -280,6 +351,82 @@ where value->>'$ref' like '#/components/parameters/%';
 
 -- does not show a POST operation object for non auto-updatable views
 select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;
+ value 
+-------
+ f
+(1 row)
+
+-- PATCH operation object
+-- shows the table name as tag
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'tags');
+    jsonb_pretty    
+--------------------
+ [                 +
+     "big_products"+
+ ]
+(1 row)
+
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'responses'->'200');
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "$ref": "#/components/responses/notEmpty.big_products",+
+     "description": "OK"                                    +
+ }
+(1 row)
+
+-- uses a reference for the 204 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'responses'->'204');
+                jsonb_pretty                 
+---------------------------------------------
+ {                                          +
+     "$ref": "#/components/responses/empty",+
+     "description": "No Content"            +
+ }
+(1 row)
+
+-- uses a reference for error responses
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'responses'->'default');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/responses/defaultError",+
+     "description": "Error"                        +
+ }
+(1 row)
+
+-- uses references for columns as query parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
+                              value                              
+-----------------------------------------------------------------
+ {"$ref": "#/components/parameters/rowFilter.big_products.id"}
+ {"$ref": "#/components/parameters/rowFilter.big_products.code"}
+ {"$ref": "#/components/parameters/rowFilter.big_products.name"}
+ {"$ref": "#/components/parameters/rowFilter.big_products.size"}
+(4 rows)
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%';
+                      value                      
+-------------------------------------------------
+ {"$ref": "#/components/parameters/select"}
+ {"$ref": "#/components/parameters/columns"}
+ {"$ref": "#/components/parameters/order"}
+ {"$ref": "#/components/parameters/limit"}
+ {"$ref": "#/components/parameters/or"}
+ {"$ref": "#/components/parameters/and"}
+ {"$ref": "#/components/parameters/not.or"}
+ {"$ref": "#/components/parameters/not.and"}
+ {"$ref": "#/components/parameters/preferPatch"}
+(9 rows)
+
+-- does not show a PATCH operation object for non auto-updatable views
+select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'patch' as value;
  value 
 -------
  f

--- a/test/expected/paths.out
+++ b/test/expected/paths.out
@@ -43,21 +43,21 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get
   
 -- uses a reference for the 200 HTTP code response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'200');
-                    jsonb_pretty                    
-----------------------------------------------------
- {                                                 +
-     "$ref": "#/components/responses/get.products",+
-     "description": "OK"                           +
+                      jsonb_pretty                       
+---------------------------------------------------------
+ {                                                      +
+     "$ref": "#/components/responses/notEmpty.products",+
+     "description": "OK"                                +
  }
 (1 row)
 
 -- uses a reference for the 206 HTTP code response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'get'->'responses'->'206');
-                    jsonb_pretty                    
-----------------------------------------------------
- {                                                 +
-     "$ref": "#/components/responses/get.products",+
-     "description": "Partial Content"              +
+                      jsonb_pretty                       
+---------------------------------------------------------
+ {                                                      +
+     "$ref": "#/components/responses/notEmpty.products",+
+     "description": "Partial Content"                   +
  }
 (1 row)
 
@@ -115,11 +115,11 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'pos
 
 -- uses a reference for the 201 HTTP code response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'responses'->'201');
-                    jsonb_pretty                     
------------------------------------------------------
- {                                                  +
-     "$ref": "#/components/responses/post.products",+
-     "description": "Created"                       +
+                       jsonb_pretty                        
+-----------------------------------------------------------
+ {                                                        +
+     "$ref": "#/components/responses/mayBeEmpty.products",+
+     "description": "Created"                             +
  }
 (1 row)
 
@@ -165,21 +165,21 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->
   
 -- uses a reference for the 200 HTTP code response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'200');
-                      jsonb_pretty                      
---------------------------------------------------------
- {                                                     +
-     "$ref": "#/components/responses/get.big_products",+
-     "description": "OK"                               +
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "$ref": "#/components/responses/notEmpty.big_products",+
+     "description": "OK"                                    +
  }
 (1 row)
 
 -- uses a reference for the 206 HTTP code response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'get'->'responses'->'206');
-                      jsonb_pretty                      
---------------------------------------------------------
- {                                                     +
-     "$ref": "#/components/responses/get.big_products",+
-     "description": "Partial Content"                  +
+                        jsonb_pretty                         
+-------------------------------------------------------------
+ {                                                          +
+     "$ref": "#/components/responses/notEmpty.big_products",+
+     "description": "Partial Content"                       +
  }
 (1 row)
 
@@ -242,11 +242,11 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->
 
 -- uses a reference for the 201 HTTP code response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'post'->'responses'->'201');
-                      jsonb_pretty                       
----------------------------------------------------------
- {                                                      +
-     "$ref": "#/components/responses/post.big_products",+
-     "description": "Created"                           +
+                         jsonb_pretty                          
+---------------------------------------------------------------
+ {                                                            +
+     "$ref": "#/components/responses/mayBeEmpty.big_products",+
+     "description": "Created"                                 +
  }
 (1 row)
 

--- a/test/expected/responses.out
+++ b/test/expected/responses.out
@@ -31,7 +31,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 -- Tables
 -- GET operation object
 -- defines an application/json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'application/json');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -45,7 +45,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'application/vnd.pgrst.object+json');
                   jsonb_pretty                   
 -------------------------------------------------
  {                                              +
@@ -56,7 +56,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                   jsonb_pretty                   
 -------------------------------------------------
  {                                              +
@@ -67,7 +67,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -80,7 +80,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 
 -- POST operation object
 -- defines an application/json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'application/json');
                         jsonb_pretty                         
 -------------------------------------------------------------
  {                                                          +
@@ -101,7 +101,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'application/vnd.pgrst.object+json');
                       jsonb_pretty                       
 ---------------------------------------------------------
  {                                                      +
@@ -119,7 +119,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                       jsonb_pretty                       
 ---------------------------------------------------------
  {                                                      +
@@ -137,7 +137,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -150,7 +150,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 
 -- Views
 -- GET operation object
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'application/json');
                       jsonb_pretty                       
 ---------------------------------------------------------
  {                                                      +
@@ -164,7 +164,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'application/vnd.pgrst.object+json');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -175,7 +175,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                     jsonb_pretty                     
 -----------------------------------------------------
  {                                                  +
@@ -186,7 +186,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -198,7 +198,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines a GET operation object for non auto-updatable views
-select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'notEmpty.non_auto_updatable' as value;
  value 
 -------
  t
@@ -206,7 +206,7 @@ select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_au
 
 -- POST operation object
 -- defines an application/json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'application/json');
                           jsonb_pretty                           
 -----------------------------------------------------------------
  {                                                              +
@@ -227,7 +227,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'application/vnd.pgrst.object+json');
                         jsonb_pretty                         
 -------------------------------------------------------------
  {                                                          +
@@ -245,7 +245,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
                         jsonb_pretty                         
 -------------------------------------------------------------
  {                                                          +
@@ -263,7 +263,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'text/csv');
        jsonb_pretty        
 ---------------------------
  {                        +
@@ -275,7 +275,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- does not define a POST operation object for non auto-updatable views
-select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'mayBeEmpty.non_auto_updatable' as value;
  value 
 -------
  f

--- a/test/expected/responses.out
+++ b/test/expected/responses.out
@@ -28,8 +28,17 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
  }
 (1 row)
 
+-- defines an empty response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'empty');
+                          jsonb_pretty                           
+-----------------------------------------------------------------
+ {                                                              +
+     "description": "No media types when response body is empty"+
+ }
+(1 row)
+
 -- Tables
--- GET operation object
+-- Non-empty response body
 -- defines an application/json response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'application/json');
                     jsonb_pretty                     
@@ -78,7 +87,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
  }
 (1 row)
 
--- POST operation object
+-- Empty or non-empty response body
 -- defines an application/json response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'application/json');
                         jsonb_pretty                         
@@ -149,7 +158,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
 (1 row)
 
 -- Views
--- GET operation object
+-- Non-empty response body
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'application/json');
                       jsonb_pretty                       
 ---------------------------------------------------------
@@ -197,14 +206,14 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
  }
 (1 row)
 
--- defines a GET operation object for non auto-updatable views
+-- defines a non-empty response body for non auto-updatable views
 select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'notEmpty.non_auto_updatable' as value;
  value 
 -------
  t
 (1 row)
 
--- POST operation object
+-- Empty or non-empty response body
 -- defines an application/json response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'application/json');
                           jsonb_pretty                           
@@ -274,7 +283,7 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'-
  }
 (1 row)
 
--- does not define a POST operation object for non auto-updatable views
+-- does not define an empty or non-empty response body for non auto-updatable views
 select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'mayBeEmpty.non_auto_updatable' as value;
  value 
 -------

--- a/test/sql/paths.sql
+++ b/test/sql/paths.sql
@@ -45,6 +45,30 @@ select value
 from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'post'->'parameters')
 where value->>'$ref' like '#/components/parameters/%';
 
+-- PATCH operation object
+
+-- shows the table name as tag
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'tags');
+
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'responses'->'200');
+
+-- uses a reference for the 204 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'responses'->'204');
+
+-- uses a reference for error responses
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'responses'->'default');
+
+-- uses references for columns as query parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.products.%';
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/products'->'patch'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.products.%';
+
 -- Views
 -- GET operation object
 
@@ -94,3 +118,30 @@ where value->>'$ref' like '#/components/parameters/%';
 
 -- does not show a POST operation object for non auto-updatable views
 select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'post' as value;
+
+-- PATCH operation object
+
+-- shows the table name as tag
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'tags');
+
+-- uses a reference for the 200 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'responses'->'200');
+
+-- uses a reference for the 204 HTTP code response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'responses'->'204');
+
+-- uses a reference for error responses
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'responses'->'default');
+
+-- uses references for columns as query parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'parameters')
+where value->>'$ref' like '#/components/parameters/rowFilter.big_products.%';
+
+-- uses references for common parameters
+select value
+from jsonb_array_elements(postgrest_openapi_spec('{test}')->'paths'->'/big_products'->'patch'->'parameters')
+where value->>'$ref' not like '#/components/parameters/rowFilter.big_products.%';
+
+-- does not show a PATCH operation object for non auto-updatable views
+select postgrest_openapi_spec('{test}')->'paths'->'/non_auto_updatable' ? 'patch' as value;

--- a/test/sql/responses.sql
+++ b/test/sql/responses.sql
@@ -1,6 +1,9 @@
 -- defines a default error response
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
 
+-- defines an empty response
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'empty');
+
 -- Tables
 -- Non-empty response body
 

--- a/test/sql/responses.sql
+++ b/test/sql/responses.sql
@@ -2,64 +2,64 @@
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'defaultError');
 
 -- Tables
--- GET operation object
+-- Non-empty response body
 
 -- defines an application/json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.products'->'content'->'text/csv');
 
--- POST operation object
+-- Empty or non-empty response body
 
 -- defines an application/json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.products'->'content'->'text/csv');
 
 -- Views
--- GET operation object
+-- Non-empty response body
 
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'get.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'notEmpty.big_products'->'content'->'text/csv');
 
--- defines a GET operation object for non auto-updatable views
-select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'get.non_auto_updatable' as value;
+-- defines a non-empty response body for non auto-updatable views
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'notEmpty.non_auto_updatable' as value;
 
--- POST operation object
+-- Empty or non-empty response body
 
 -- defines an application/json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'application/json');
 
 -- defines an application/vnd.pgrst.object+json response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'application/vnd.pgrst.object+json');
 
 -- defines an application/vnd.pgrst.object+json;nulls=stripped response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'application/vnd.pgrst.object+json;nulls=stripped');
 
 -- defines a text/csv response
-select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'post.big_products'->'content'->'text/csv');
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'responses'->'mayBeEmpty.big_products'->'content'->'text/csv');
 
--- does not define a POST operation object for non auto-updatable views
-select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'post.non_auto_updatable' as value;
+-- does not define an empty or non-empty response body for non auto-updatable views
+select postgrest_openapi_spec('{test}')->'components'->'responses' ? 'mayBeEmpty.non_auto_updatable' as value;


### PR DESCRIPTION
Does the following:

- Adds `patch` operation object to `paths` for every table and view.
- Renames the `responses` references: it uses the more accurate response body type (empty or not empty) instead of the http method.
- Adds a common `empty` response body to `responses`