### PR TITLE
Add query to get all functions and detect composite types in arguments and return values

### DIFF
--- a/sql/components.sql
+++ b/sql/components.sql
@@ -1,7 +1,7 @@
 -- Functions to build the Components Object of the OAS document
 
 create or replace function oas_build_components(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select oas_components_object(
   schemas := oas_build_component_schemas(schemas),
@@ -15,7 +15,7 @@ $$;
 -- Schemas
 
 create or replace function oas_build_component_schemas(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select oas_build_component_schemas_from_tables(schemas) ||
          oas_build_component_schemas_from_composite_types(schemas) ||
@@ -23,7 +23,7 @@ $$
 $$;
 
 create or replace function oas_build_component_schemas_from_tables(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_object_agg(x.table_name, x.oas_schema)
 from (
@@ -40,7 +40,7 @@ from (
 $$;
 
 create or replace function oas_build_component_schemas_from_composite_types(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 SELECT coalesce(jsonb_object_agg(x.ct_name, x.oas_schema), '{}')
 FROM (
@@ -55,7 +55,7 @@ FROM (
 $$;
 
 create or replace function oas_build_component_schemas_headers()
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_build_object(
   'header.preferParams',
@@ -174,7 +174,7 @@ $$;
 -- Parameters
 
 create or replace function oas_build_component_parameters(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select oas_build_component_parameters_query_params_from_tables(schemas) ||
          oas_build_component_parameters_query_params_common() ||
@@ -182,7 +182,7 @@ $$
 $$;
 
 create or replace function oas_build_component_parameters_query_params_from_tables(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_object_agg(x.param_name, x.param_schema)
 from (
@@ -203,7 +203,7 @@ from (
 $$;
 
 create or replace function oas_build_component_parameters_query_params_common()
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_object_agg(name, param_object) from unnest(
   array['select','order', 'limit', 'offset', 'on_conflict', 'columns', 'or', 'and', 'not.or', 'not.and'],
@@ -305,7 +305,7 @@ select jsonb_object_agg(name, param_object) from unnest(
 $$;
 
 create or replace function oas_build_component_parameters_headers_common ()
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_build_object(
   'preferGet',
@@ -526,14 +526,14 @@ $$;
 -- Responses
 
 create or replace function oas_build_response_objects(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select oas_build_response_objects_from_tables(schemas) ||
        oas_build_response_objects_common();
 $$;
 
 create or replace function oas_build_response_objects_from_tables(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_object_agg(x.not_empty, x.not_empty_response) ||
        jsonb_object_agg(x.may_be_empty, x.may_be_empty_response)
@@ -623,7 +623,7 @@ from (
 $$;
 
 create or replace function oas_build_response_objects_common()
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_build_object(
   'defaultError',
@@ -655,13 +655,13 @@ $$;
 -- Request bodies
 
 create or replace function oas_build_request_bodies(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select oas_build_request_bodies_from_tables(schemas);
 $$;
 
 create or replace function oas_build_request_bodies_from_tables(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_object_agg(x.table_name, x.oas_req_body)
 from (
@@ -704,7 +704,7 @@ $$;
 -- Security Schemes
 
 create or replace function oas_build_component_security_schemes ()
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_build_object(
   'JWT',

--- a/sql/main.sql
+++ b/sql/main.sql
@@ -10,7 +10,7 @@ create or replace function callable_root() returns jsonb as $$
     proa_version := '0.1'::text, -- TODO: needs to be updated; put into config, and have Makefile update
     document_version := 'unset'::text
   );
-$$ language sql;
+$$ language sql volatile;
 
 -- This one returns the OpenAPI JSON; instead of calling it directly, call "callable_root", below
 create or replace function postgrest_openapi_spec(
@@ -19,7 +19,7 @@ create or replace function postgrest_openapi_spec(
   proa_version text default null,
   document_version text default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select oas_openapi_object(
   openapi := '3.1.0',

--- a/sql/openapi.sql
+++ b/sql/openapi.sql
@@ -19,7 +19,7 @@ create or replace function oas_openapi_object(
   tags jsonb default null,
   externalDocs jsonb default null
 )
-  returns jsonb language sql as
+  returns jsonb language sql stable as
 $$
 select jsonb_strip_nulls(
     jsonb_build_object(
@@ -47,7 +47,7 @@ create or replace function oas_info_object(
   contact jsonb default null,
   license jsonb default null
 )
-  returns jsonb language sql as
+  returns jsonb language sql stable as
 $$
 select jsonb_build_object(
     'title', title,
@@ -65,7 +65,7 @@ create or replace function oas_x_software_object(
   version text,
   description text
 )
-  returns jsonb language sql as
+  returns jsonb language sql stable as
 $$
 select json_build_object(
   'x-name', name,
@@ -86,7 +86,7 @@ create or replace function oas_components_object(
   callbacks jsonb default null,
   pathItems jsonb default null
 )
-  returns jsonb language sql as
+  returns jsonb language sql stable as
 $$
 select json_build_object(
  'schemas', schemas,
@@ -138,7 +138,7 @@ create or replace function oas_schema_object(
   example jsonb default null,
   deprecated boolean default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   -- TODO: build the JSON object according to the type
   select jsonb_build_object(
@@ -184,7 +184,7 @@ create or replace function oas_reference_object(
   summary text default null,
   description text default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select json_build_object(
   '$ref', ref,
@@ -206,7 +206,7 @@ create or replace function oas_parameter_object(
   example jsonb default null,
   examples jsonb default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   -- TODO: Add missing logic between fields (e.g. example and examples are mutually exclusive)
   select jsonb_build_object(
@@ -235,7 +235,7 @@ create or replace function oas_security_scheme_object(
   flows jsonb default null,
   openIdConnectUrl text default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select jsonb_build_object(
     'type', type,
@@ -255,7 +255,7 @@ create or replace function oas_example_object(
   value jsonb default null,
   externalValue text default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select jsonb_build_object(
     'summary', summary,
@@ -280,7 +280,7 @@ create or replace function oas_path_item_object(
   servers jsonb default null,
   parameters jsonb default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select json_build_object(
     '$ref', ref,
@@ -313,7 +313,7 @@ create or replace function oas_operation_object(
   security jsonb default null,
   servers jsonb default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select json_build_object(
     'tags', tags,
@@ -337,7 +337,7 @@ create or replace function oas_response_object(
   content jsonb default null,
   links jsonb default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select json_build_object(
     'description', description,
@@ -353,7 +353,7 @@ create or replace function oas_media_type_object(
   examples jsonb default null,
   encoding jsonb default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select json_build_object(
     'schema', "schema",
@@ -368,7 +368,7 @@ create or replace function oas_request_body_object(
   description text default null,
   required boolean default null
 )
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select json_build_object(
     'content', content,

--- a/sql/paths.sql
+++ b/sql/paths.sql
@@ -1,14 +1,14 @@
 -- Functions to build the Paths Object of the OAS document
 
 create or replace function oas_build_paths(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
   select oas_build_path_item_root() ||
          oas_build_path_items_from_tables(schemas);
 $$;
 
 create or replace function oas_build_path_items_from_tables(schemas text[])
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select jsonb_object_agg(x.path, x.oas_path_item)
 from (
@@ -129,7 +129,7 @@ from (
 $$;
 
 create or replace function oas_build_path_item_root()
-returns jsonb language sql as
+returns jsonb language sql stable as
 $$
 select
   jsonb_build_object(

--- a/sql/postgrest.sql
+++ b/sql/postgrest.sql
@@ -271,7 +271,7 @@ returns table (
   comptype_name text,
   comptype_description text,
   columns jsonb
-) language sql as
+) language sql stable as
 $$
 WITH
   columns AS (
@@ -455,7 +455,7 @@ create or replace function postgrest_get_schema_description(schema text)
 returns table (
   title text,
   description text
-) language sql as
+) language sql stable as
 $$
 select
   substr(sd.schema_desc, 0, break_position) as title,

--- a/sql/postgrest.sql
+++ b/sql/postgrest.sql
@@ -367,8 +367,12 @@ WITH
         item_is_composite,
         item_comptype_id
       FROM columns
-      -- List only the the composite types that are used by tables in the exposed schema
-      WHERE comptype_id in (select unnest(composite_cols) from postgrest_get_all_tables(schemas))
+      -- List only the the composite types that are used by tables and functions in the exposed schema
+      WHERE comptype_id in (
+        select unnest(composite_cols) from postgrest_get_all_tables(schemas)
+        union
+        select unnest(composite_args_ret) from postgrest_get_all_functions(schemas)
+      )
       UNION
       SELECT
         c.comptype_schema,
@@ -449,6 +453,195 @@ FROM pg_class c
   JOIN columns_agg cols_agg ON n.nspname = cols_agg.comptype_schema AND c.relname = cols_agg.comptype_name
 WHERE c.relkind = 'c'
   AND n.nspname NOT IN ('pg_catalog', 'information_schema');
+$$;
+
+-- TODO: simplify the query to have only relevant info for OpenAPI
+-- TODO: Further optimize the query (takes ~160ms compared to ~17ms from the query in the core repo)
+create or replace function postgrest_get_all_functions(schemas text[])
+returns table (
+  proc_schema text,
+  proc_name text,
+  proc_description text,
+  schema text,
+  name text,
+  rettype_is_setof boolean,
+  rettype_is_composite boolean,
+  rettype_is_table boolean,
+  rettype_is_composite_alias boolean,
+  provolatile char,
+  hasvariadic boolean,
+  transaction_isolation_level text,
+  statement_timeout text,
+  composite_args_ret oid[],
+  required_args text[],
+  all_args text[],
+  args jsonb
+) language sql stable as
+$$
+ -- Recursively get the base types of domains
+  WITH
+  base_types AS (
+    WITH RECURSIVE
+    recurse AS (
+      SELECT
+        oid,
+        typbasetype,
+        COALESCE(NULLIF(typbasetype, 0), oid) AS base
+      FROM pg_type
+      UNION
+      SELECT
+        t.oid,
+        b.typbasetype,
+        COALESCE(NULLIF(b.typbasetype, 0), b.oid) AS base
+      FROM recurse t
+      JOIN pg_type b ON t.typbasetype = b.oid
+    )
+    SELECT
+      oid,
+      base
+    FROM recurse
+    WHERE typbasetype = 0
+  ),
+  arguments AS (
+    SELECT
+      p.oid as proc_oid,
+      pa.idx AS idx,
+      COALESCE(pa.name, '') as name,
+      type,
+      CASE type
+        WHEN 'bit'::regtype THEN 'bit varying'
+        WHEN 'bit[]'::regtype THEN 'bit varying[]'
+        WHEN 'character'::regtype THEN 'character varying'
+        WHEN 'character[]'::regtype THEN 'character varying[]'
+        ELSE type::regtype::text
+      END AS type_ignore_length, -- convert types that ignore the lenth and accept any value till maximum size
+      pa.idx <= (p.pronargs - p.pronargdefaults) AS is_required,
+      t.typarray = 0 AS is_array,
+      t.typtype = 'c' AS is_composite,
+      t.typrelid AS composite_oid,
+      CASE
+        WHEN t.typtype = 'd' THEN
+          CASE
+            WHEN nbt.nspname = 'pg_catalog'::name THEN format_type(t.typbasetype, NULL::integer)
+            ELSE format_type(pa.type, NULL::integer)
+            END
+        ELSE format_type(pa.type, NULL::integer)
+        END::text AS data_type,
+      t.oid AS data_type_id,
+      COALESCE(bt.typname, t.typname)::name AS udt_name,
+      CASE
+        WHEN t_arr.typtype = 'd' THEN
+          CASE
+            WHEN nbt_arr.nspname = 'pg_catalog'::name THEN format_type(t_arr.typbasetype, NULL::integer)
+            ELSE format_type(t_arr.oid, t_arr.typtypmod)
+            END
+        ELSE
+          CASE
+            WHEN nt_arr.nspname = 'pg_catalog'::name THEN format_type(t_arr.oid, NULL::integer)
+            ELSE format_type(t_arr.oid, t_arr.typtypmod)
+            END
+        END::text AS item_data_type,
+      t_arr.typtype = 'c' AS item_is_composite,
+      t_arr.typrelid AS item_composite_oid,
+      t_arr.oid AS item_data_type_id,
+      COALESCE(mode = 'v', FALSE) AS is_variadic
+    FROM pg_proc p
+      CROSS JOIN unnest(proargnames, proargtypes, proargmodes)
+        WITH ORDINALITY AS pa (name, type, mode, idx)
+      JOIN (pg_type t JOIN pg_namespace nt ON t.typnamespace = nt.oid)
+        ON pa.type = t.oid
+      LEFT JOIN (pg_type bt JOIN pg_namespace nbt ON bt.typnamespace = nbt.oid)
+        ON t.typtype = 'd' AND t.typbasetype = bt.oid
+      LEFT JOIN (pg_type t_arr JOIN pg_namespace nt_arr ON t_arr.typnamespace = nt_arr.oid)
+        ON t.oid = t_arr.typarray
+      LEFT JOIN (pg_type bt_arr JOIN pg_namespace nbt_arr ON bt_arr.typnamespace = nbt_arr.oid)
+        ON t_arr.typtype = 'd' AND t_arr.typbasetype = bt_arr.oid
+    -- TODO: Add output arguments (including "returns table") to build the response object schema
+    WHERE pa.type IS NOT NULL -- only input arguments
+  ),
+  arguments_agg AS (
+    SELECT
+      info.proc_oid as oid,
+      array_agg(coalesce(info.composite_oid, info.item_composite_oid)) filter (where info.is_composite or info.item_is_composite) AS composite_args,
+      array_agg(info.name order by info.idx) filter (where info.is_required) AS required_args,
+      array_agg(info.name order by info.idx) AS all_args,
+      jsonb_object_agg(
+        info.name,
+          case when info.is_composite then
+            oas_build_reference_to_schemas(info.data_type)
+          else
+            oas_schema_object(
+              type := pgtype_to_oastype(info.data_type),
+              format := info.data_type::text,
+              -- TODO: take default values from pg_proc.pronargdefaults
+              -- "default" :=  to_jsonb(info.arg_default),
+              enum := to_jsonb(enum_info.vals),
+              items :=
+                case
+                when not info.is_array then
+                  null
+                when info.item_is_composite then
+                  oas_build_reference_to_schemas(info.item_data_type)
+                else
+                  oas_schema_object(
+                    type := pgtype_to_oastype(info.item_data_type),
+                    format := info.item_data_type::text
+                  )
+                end
+            )
+          end order by info.idx
+      ) as args,
+      CASE COUNT(*) - COUNT(nullif(info.name,'')) -- number of unnamed arguments
+        WHEN 0 THEN true
+        WHEN 1 THEN COUNT(*) = 1 AND (array_agg(info.type))[1] IN ('bytea'::regtype, 'json'::regtype, 'jsonb'::regtype, 'text'::regtype, 'xml'::regtype)
+        ELSE false
+      END AS callable
+    FROM arguments as info
+      LEFT OUTER JOIN (
+        SELECT
+          n.nspname AS s,
+          t.typname AS n,
+          array_agg(e.enumlabel ORDER BY e.enumsortorder) AS vals
+        FROM pg_type t
+               JOIN pg_enum e ON t.oid = e.enumtypid
+               JOIN pg_namespace n ON n.oid = t.typnamespace
+        GROUP BY s,n
+      ) AS enum_info ON info.udt_name = enum_info.n
+    GROUP BY proc_oid
+  )
+  SELECT
+    pn.nspname AS proc_schema,
+    p.proname AS proc_name,
+    d.description AS proc_description,
+    tn.nspname AS schema,
+    COALESCE(comp.relname, t.typname) AS name,
+    p.proretset AS rettype_is_setof,
+    t.typtype = 'c' AS rettype_is_composite,
+    COALESCE(proargmodes::text[] @> '{t}', false) AS rettype_is_table,
+    -- TODO: add support for rettype out/inout
+    bt.oid <> bt.base as rettype_is_composite_alias,
+    p.provolatile,
+    p.provariadic > 0 as hasvariadic,
+    lower((regexp_split_to_array((regexp_split_to_array(iso_config, '='))[2], ','))[1]) AS transaction_isolation_level,
+    lower((regexp_split_to_array((regexp_split_to_array(timeout_config, '='))[2], ','))[1]) AS statement_timeout,
+    a.composite_args || case when t.typtype = 'c' then t.typrelid end as composite_args_ret,
+    a.required_args,
+    a.all_args,
+    COALESCE(a.args, '{}') AS args
+  FROM pg_proc p
+  LEFT JOIN arguments_agg a ON a.oid = p.oid
+  JOIN pg_namespace pn ON pn.oid = p.pronamespace
+  JOIN base_types bt ON bt.oid = p.prorettype
+  JOIN pg_type t ON t.oid = bt.base
+  JOIN pg_namespace tn ON tn.oid = t.typnamespace
+  -- TODO: Add support for functions returning array types (extra joins needed)
+  LEFT JOIN pg_class comp ON comp.oid = t.typrelid
+  LEFT JOIN pg_description as d ON d.objoid = p.oid
+  LEFT JOIN LATERAL unnest(proconfig) iso_config ON iso_config like 'default_transaction_isolation%'
+  LEFT JOIN LATERAL unnest(proconfig) timeout_config ON timeout_config like 'statement_timeout%'
+  WHERE t.oid <> 'trigger'::regtype AND COALESCE(a.callable, true)
+    AND prokind = 'f'
+    AND pn.nspname = ANY(schemas);
 $$;
 
 create or replace function postgrest_get_schema_description(schema text)

--- a/sql/servers.sql
+++ b/sql/servers.sql
@@ -78,7 +78,7 @@ BEGIN
 
   RETURN json_result;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;
 
 CREATE OR REPLACE PROCEDURE set_server_from_configuration()
 AS $$

--- a/sql/utils.sql
+++ b/sql/utils.sql
@@ -1,7 +1,7 @@
 -- Functions that help in building the OpenAPI spec inside PostgreSQL
 
 create or replace function pgtype_to_oastype(type text)
-returns text language sql as
+returns text language sql immutable as
 $$
 select case when type like any(array['character', 'character varying', 'text']) then 'string'
             when type like any(array['double precision', 'numeric', 'real']) then 'number'

--- a/test/expected/schemas.out
+++ b/test/expected/schemas.out
@@ -1,3 +1,4 @@
+-- Tables
 -- detects tables as objects
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'type');
  jsonb_pretty 
@@ -285,6 +286,146 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'
  }
 (1 row)
 
+-- Functions
+-- Types inside arguments
+-- detects composite types as objects
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_arg'->'type');
+ jsonb_pretty 
+--------------
+ "object"
+(1 row)
+
+-- references a composite type column from another composite type to a component definition
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_arg'->'properties'->'dim');
+                      jsonb_pretty                      
+--------------------------------------------------------
+ {                                                     +
+     "$ref": "#/components/schemas/types.dimension_arg"+
+ }
+(1 row)
+
+-- detects a composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension_arg');
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "type": "object",          +
+     "properties": {            +
+         "hei": {               +
+             "type": "number",  +
+             "format": "numeric"+
+         },                     +
+         "len": {               +
+             "type": "number",  +
+             "format": "numeric"+
+         },                     +
+         "wid": {               +
+             "type": "number",  +
+             "format": "numeric"+
+         }                      +
+     }                          +
+ }
+(1 row)
+
+-- detects an array composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color_arg');
+            jsonb_pretty            
+------------------------------------
+ {                                 +
+     "type": "object",             +
+     "properties": {               +
+         "def": {                  +
+             "type": "string",     +
+             "format": "text"      +
+         },                        +
+         "hex": {                  +
+             "type": "string",     +
+             "format": "character",+
+             "maxLength": 6        +
+         }                         +
+     }                             +
+ }
+(1 row)
+
+-- references a composite type column from an array composite type inside the items property
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_arg'->'properties'->'colors'->'items');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/schemas/types.color_arg"+
+ }
+(1 row)
+
+-- Types inside returning values
+-- detects composite types as objects
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_ret'->'type');
+ jsonb_pretty 
+--------------
+ "object"
+(1 row)
+
+-- references a composite type column from another composite type to a component definition
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_ret'->'properties'->'dim');
+                      jsonb_pretty                      
+--------------------------------------------------------
+ {                                                     +
+     "$ref": "#/components/schemas/types.dimension_ret"+
+ }
+(1 row)
+
+-- detects a composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension_ret');
+          jsonb_pretty           
+---------------------------------
+ {                              +
+     "type": "object",          +
+     "properties": {            +
+         "hei": {               +
+             "type": "number",  +
+             "format": "numeric"+
+         },                     +
+         "len": {               +
+             "type": "number",  +
+             "format": "numeric"+
+         },                     +
+         "wid": {               +
+             "type": "number",  +
+             "format": "numeric"+
+         }                      +
+     }                          +
+ }
+(1 row)
+
+-- detects an array composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color_ret');
+            jsonb_pretty            
+------------------------------------
+ {                                 +
+     "type": "object",             +
+     "properties": {               +
+         "def": {                  +
+             "type": "string",     +
+             "format": "text"      +
+         },                        +
+         "hex": {                  +
+             "type": "string",     +
+             "format": "character",+
+             "maxLength": 6        +
+         }                         +
+     }                             +
+ }
+(1 row)
+
+-- references a composite type column from an array composite type inside the items property
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_ret'->'properties'->'colors'->'items');
+                    jsonb_pretty                    
+----------------------------------------------------
+ {                                                 +
+     "$ref": "#/components/schemas/types.color_ret"+
+ }
+(1 row)
+
+-- Common
 -- defines all the available prefer headers
 select key, jsonb_pretty(value)
 from jsonb_each(postgrest_openapi_spec('{test}')->'components'->'schemas')

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -11,6 +11,16 @@ create type types.attribute as (dim types.dimension, colors types.color[], other
 create type types.hiddentype as (val text);
 create type types.size as enum('XS', 'S', 'M', 'L', 'XL');
 
+-- The detection of types used in functions need to be tested for arguments and returning values separately.
+-- Used to test the detection of custom types inside the arguments
+create type types.dimension_arg as (len numeric, wid numeric, hei numeric);
+create type types.color_arg as (hex char(6), def text);
+create type types.attribute_arg as (dim types.dimension_arg, colors types.color_arg[], other text);
+-- Used to test the detection of custom types inside the returning values
+create type types.dimension_ret as (len numeric, wid numeric, hei numeric);
+create type types.color_ret as (hex char(6), def text);
+create type types.attribute_ret as (dim types.dimension_ret, colors types.color_ret[], other text);
+
 comment on type types.attribute is
 $$Attribute summary
 
@@ -79,6 +89,20 @@ create view test.big_products as
 
 create view test.non_auto_updatable as
   select 'this view is not auto updatable' as description;
+
+create function test.get_products_by_size(s types.size)
+returns setof test.products stable language sql as
+$$
+  select *
+  from test.products
+  where size = s;
+$$;
+
+create function test.get_attribute(loc types.attribute_arg)
+returns types.attribute_ret stable language sql as
+$$
+  select ((1,2,3),array[('a','b')]::types.color_ret[],'a');
+$$;
 
 create schema private;
 

--- a/test/sql/schemas.sql
+++ b/test/sql/schemas.sql
@@ -1,3 +1,5 @@
+-- Tables
+
 -- detects tables as objects
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'products'->'type');
 
@@ -45,6 +47,43 @@ select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'
 
 -- references a composite type column from an array composite type inside the items property
 select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute'->'properties'->'colors'->'items');
+
+-- Functions
+
+-- Types inside arguments
+-- detects composite types as objects
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_arg'->'type');
+
+-- references a composite type column from another composite type to a component definition
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_arg'->'properties'->'dim');
+
+-- detects a composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension_arg');
+
+-- detects an array composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color_arg');
+
+-- references a composite type column from an array composite type inside the items property
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_arg'->'properties'->'colors'->'items');
+
+-- Types inside returning values
+
+-- detects composite types as objects
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_ret'->'type');
+
+-- references a composite type column from another composite type to a component definition
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_ret'->'properties'->'dim');
+
+-- detects a composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.dimension_ret');
+
+-- detects an array composite type inside another composite type
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.color_ret');
+
+-- references a composite type column from an array composite type inside the items property
+select jsonb_pretty(postgrest_openapi_spec('{test}')->'components'->'schemas'->'types.attribute_ret'->'properties'->'colors'->'items');
+
+-- Common
 
 -- defines all the available prefer headers
 select key, jsonb_pretty(value)


### PR DESCRIPTION
The basic query to get function info in PostgREST core needs some tweaks to get more complete data:

- [x] Composite types for parameters (simple and arrays)
- [x] Composite types for returning values (arrays)
- [x] Modify `postgrest_get_all_composite_types` to include the composite types from parameters and returning types in functions.